### PR TITLE
CIR3-89 tested dialogs, had to add abstract native dialogs to mock the service

### DIFF
--- a/packages/wisecore/lib/src/dialogs/error_dialog_helper.dart
+++ b/packages/wisecore/lib/src/dialogs/error_dialog_helper.dart
@@ -3,6 +3,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_platform_alert/flutter_platform_alert.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:wisecore/src/dialogs/platform_alert_service.dart';
 
 import '../extensions/extensions.dart';
 
@@ -12,6 +13,7 @@ class ErrorDialog {
   ErrorDialog({
     required this.networkErrorString,
     required this.appName,
+    required this.alertService
   });
 
   /// Fall back error message
@@ -20,24 +22,28 @@ class ErrorDialog {
   /// Application name used as dialog title
   String appName;
 
+  /// Platform alert service
+  final PlatformAlertService alertService;
+
   /// Shows error dialog
   Future<void> showErrorDialog<T>(
     BuildContext context,
     AsyncValue<T> asyncValue, {
     String? customErrorMessage,
   }) async {
-    final message = _getErrorMessage(value: asyncValue);
+    final message = getErrorMessage(value: asyncValue);
 
     if (message != null || customErrorMessage != null) {
-      await FlutterPlatformAlert.showAlert(
-        windowTitle: appName,
-        text: customErrorMessage ?? message!,
+      await alertService.showAlert(
+        title: appName,
+        message: customErrorMessage ?? message!,
         iconStyle: IconStyle.error,
       );
     }
   }
 
-  String? _getErrorMessage({required AsyncValue<dynamic> value}) {
+  /// Returns error message from [AsyncValue]
+  String? getErrorMessage({required AsyncValue<dynamic> value}) {
     if (!value.hasError || value.isLoading) {
       return null;
     }

--- a/packages/wisecore/lib/src/dialogs/platform_alert_service.dart
+++ b/packages/wisecore/lib/src/dialogs/platform_alert_service.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_platform_alert/flutter_platform_alert.dart';
+
+abstract class PlatformAlertService {
+  Future<void> showAlert({
+    required String title,
+    required String message,
+    required IconStyle iconStyle,
+  });
+}
+
+class FlutterPlatformAlertService implements PlatformAlertService {
+  @override
+  Future<void> showAlert({
+    required String title,
+    required String message,
+    required IconStyle iconStyle,
+  }) {
+    return FlutterPlatformAlert.showAlert(
+      windowTitle: title,
+      text: message,
+      iconStyle: iconStyle,
+    );
+  }
+}

--- a/packages/wisecore/pubspec.yaml
+++ b/packages/wisecore/pubspec.yaml
@@ -31,4 +31,11 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   custom_lint: ^0.7.0
   dependency_validator: ^4.1.2
-  
+
+  # Testing
+  test: ^1.25.15
+
+  # Mocking
+  mockito: ^5.4.0
+  flutter_test:
+    sdk: flutter

--- a/packages/wisecore/test/dialogs/dialog_test.dart
+++ b/packages/wisecore/test/dialogs/dialog_test.dart
@@ -1,0 +1,221 @@
+import 'package:flutter_platform_alert/flutter_platform_alert.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:flutter/material.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:wisecore/src/dialogs/error_dialog_helper.dart';
+import 'package:dio/dio.dart';
+import 'package:wisecore/src/dialogs/platform_alert_service.dart';
+
+class MockPlatformAlertService extends Mock implements PlatformAlertService {}
+
+void main() {
+  late ErrorDialog errorDialog;
+  const networkErrorString = 'Network error occurred';
+  const appName = 'TestApp';
+  final mockAlertService = MockPlatformAlertService();
+
+  setUpAll(() {
+    registerFallbackValue(IconStyle.error);
+  });
+
+  setUp(() {
+    errorDialog = ErrorDialog(
+      networkErrorString: networkErrorString,
+      appName: appName,
+      alertService: mockAlertService,
+    );
+  });
+
+  test('getErrorMessage returns null if no error or loading', () {
+    final asyncValue = AsyncValue<int>.loading();
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, isNull);
+  });
+
+  test('getErrorMessage returns error message from DioException', () {
+    final dioError = DioException(
+      requestOptions: RequestOptions(path: ''),
+      response: Response(
+        requestOptions: RequestOptions(path: ''),
+        data: {'message': 'Dio error occurred'},
+      ),
+    );
+    final asyncValue = AsyncValue<int>.error(dioError, StackTrace.current);
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, 'Dio error occurred');
+  });
+
+  test('getErrorMessage returns networkErrorString if no message in DioException', () {
+    final dioError = DioException(
+      requestOptions: RequestOptions(path: ''),
+    );
+    final asyncValue = AsyncValue<int>.error(dioError, StackTrace.current);
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, networkErrorString);
+  });
+
+  test('getErrorMessage returns error message from Exception', () {
+    final exception = Exception('General error occurred');
+    final asyncValue = AsyncValue<int>.error(exception, StackTrace.current);
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, 'General error occurred');
+  });
+
+  testWidgets('showErrorDialog calls alert with custom error message', (tester) async {
+    final mockAlertService = MockPlatformAlertService();
+    final dialog = ErrorDialog(
+      networkErrorString: 'Network Error',
+      appName: 'TestApp',
+      alertService: mockAlertService,
+    );
+    final asyncValue = AsyncValue<int>.error(Exception('Error'), StackTrace.current);
+
+    // Stub the alert
+    when(() => mockAlertService.showAlert(
+      title: any(named: 'title'),
+      message: any(named: 'message'),
+      iconStyle: any(named: 'iconStyle'),
+    )).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            dialog.showErrorDialog(context, asyncValue, customErrorMessage: 'Custom error');
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    verify(() => mockAlertService.showAlert(
+      title: 'TestApp',
+      message: 'Custom error',
+      iconStyle: IconStyle.error,
+    )).called(1);
+  });
+
+  testWidgets('showErrorDialog shows dialog with error message from AsyncValue', (WidgetTester tester) async {
+    final mockAlertService = MockPlatformAlertService();
+    final dialog = ErrorDialog(
+      networkErrorString: 'Network Error',
+      appName: 'TestApp',
+      alertService: mockAlertService,
+    );
+    final asyncValue = AsyncValue<int>.error(Exception('Error'), StackTrace.current);
+
+    when(() => mockAlertService.showAlert(
+      title: any(named: 'title'),
+      message: any(named: 'message'),
+      iconStyle: any(named: 'iconStyle'),
+    )).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            dialog.showErrorDialog(context, asyncValue);
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    verify(() => mockAlertService.showAlert(
+      title: 'TestApp',
+      message: 'Error',
+      iconStyle: IconStyle.error,
+    )).called(1);
+  });
+
+  testWidgets('showErrorDialog does not call alert if no error', (tester) async {
+    final mockAlertService = MockPlatformAlertService();
+    final dialog = ErrorDialog(
+      networkErrorString: 'Network Error',
+      appName: 'TestApp',
+      alertService: mockAlertService,
+    );
+    final asyncValue = AsyncValue<int>.data(42); // Success state, no error
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            dialog.showErrorDialog(context, asyncValue);
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    verifyNever(() => mockAlertService.showAlert(
+      title: any(named: 'title'),
+      message: any(named: 'message'),
+      iconStyle: any(named: 'iconStyle'),
+    ));
+  });
+
+  test('getErrorMessage returns message from DioException List<dynamic>', () {
+    final dioError = DioException(
+      requestOptions: RequestOptions(path: ''),
+      response: Response(
+        requestOptions: RequestOptions(path: ''),
+        data: [
+          {'message': 'List error message'},
+        ],
+      ),
+    );
+    final asyncValue = AsyncValue<int>.error(dioError, StackTrace.current);
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, 'List error message');
+  });
+
+  test('getErrorMessage returns networkErrorString if unknown error type', () {
+    final error = Object();
+    final asyncValue = AsyncValue<int>.error(error, StackTrace.current);
+    final message = errorDialog.getErrorMessage(value: asyncValue);
+    expect(message, networkErrorString);
+  });
+
+  testWidgets('AsyncValueExtensions.showErrorDialog calls ErrorDialog.showErrorDialog', (tester) async {
+    final mockAlertService = MockPlatformAlertService();
+    final dialog = ErrorDialog(
+      networkErrorString: 'Network Error',
+      appName: 'TestApp',
+      alertService: mockAlertService,
+    );
+    final asyncError = AsyncError<Object>(Exception('AsyncError!'), StackTrace.current);
+
+    when(() => mockAlertService.showAlert(
+      title: any(named: 'title'),
+      message: any(named: 'message'),
+      iconStyle: any(named: 'iconStyle'),
+    )).thenAnswer((_) async {});
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) {
+            asyncError.showErrorDialog(dialogShower: dialog, context: context);
+            return Container();
+          },
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    verify(() => mockAlertService.showAlert(
+      title: 'TestApp',
+      message: 'AsyncError!',
+      iconStyle: IconStyle.error,
+    )).called(1);
+  });
+}


### PR DESCRIPTION
<img width="1446" alt="image" src="https://github.com/user-attachments/assets/b06e882f-b6c2-4f1e-8339-68566c8bcbc6" />


Flutter tests cannot capture native alerts directly (like checking for find.text), because they don't render as Flutter widgets—they are handled by the OS. That's why I had to add the abstract class PlatformAlertService. This way I can mock the FlutterPlatformAlert.showAlert call instead of trying to find the text in the widget tree.