### PR TITLE
Feature/wise feedback quick wins

### DIFF
--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.2.0
+
+- Automatic device/app/OS metadata attached to every report
+  (`DeviceMetadataCollector`, opt out with `collectDeviceInfo: false`).
+- `WiseFeedbackNavigatorObserver` attaches a breadcrumb of recent routes.
+- Reporter identity via the `reporter` builder; custom fields via
+  `metadataBuilder`.
+- Optional priority (mapped to Linear's `priority`) and category selectors in
+  the form.
+- The Linear transports render a `## Context` section (reporter, category,
+  priority, environment, recent screens); the proxy transport forwards the new
+  fields.
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - Automatic device/app/OS metadata attached to every report
   (`DeviceMetadataCollector`, opt out with `collectDeviceInfo: false`).
-- `WiseFeedbackNavigatorObserver` attaches a breadcrumb of recent routes.
+- `WiseFeedbackNavigatorObserver` attaches a breadcrumb of recent routes. It
+  extends auto_route's `AutoRouterObserver`, so tab switches (bottom bar taps)
+  are recorded too.
 - Reporter identity via the `reporter` builder; custom fields via
   `metadataBuilder`.
 - Optional priority (mapped to Linear's `priority`) and category selectors in

--- a/packages/wise_feedback/README.md
+++ b/packages/wise_feedback/README.md
@@ -18,6 +18,39 @@ LinearFeedback(
 );
 ```
 
+## What gets attached
+
+By default every report includes **device, OS and app-version metadata**. Add a
+navigator observer for a **breadcrumb of recent screens**, identify the
+**reporter**, and let users pick a **priority** (mapped to Linear's priority) and
+**category**. All of it is rendered into a `## Context` section on the Linear
+issue.
+
+```dart
+final feedbackObserver = WiseFeedbackNavigatorObserver();
+
+LinearFeedback(
+  transport: LinearDirectTransport(token: myBotToken, teamId: myTeamId),
+
+  // Recent screens — also add feedbackObserver to MaterialApp.navigatorObservers.
+  navigatorObserver: feedbackObserver,
+
+  // Who reported it (resolved at submit time; async-friendly).
+  reporter: () => FeedbackReporter(id: user.id, email: user.email),
+
+  // Extra custom fields.
+  metadataBuilder: () => {'tier': user.tier, 'flag.newNav': 'on'},
+
+  // Form selectors.
+  showPriority: true, // default
+  categories: const ['Bug', 'Idea', 'Question'],
+
+  // collectDeviceInfo: false, // opt out of automatic device metadata
+
+  child: MyApp(),
+);
+```
+
 ### Tracking submission progress
 
 The feedback overlay (and its built-in form) is dismissed as soon as a report

--- a/packages/wise_feedback/README.md
+++ b/packages/wise_feedback/README.md
@@ -45,7 +45,8 @@ LinearFeedback(
   showPriority: true, // default
   categories: const ['Bug', 'Idea', 'Question'],
 
-  // collectDeviceInfo: false, // opt out of automatic device metadata
+  // Device/OS/app metadata is attached by default. Pass a metadataCollector
+  // returning an empty map to attach nothing.
 
   child: MyApp(),
 );

--- a/packages/wise_feedback/README.md
+++ b/packages/wise_feedback/README.md
@@ -26,13 +26,22 @@ navigator observer for a **breadcrumb of recent screens**, identify the
 **category**. All of it is rendered into a `## Context` section on the Linear
 issue.
 
+`WiseFeedbackNavigatorObserver` is an auto_route `AutoRouterObserver`, so it
+records tab switches (bottom bar taps) next to pushes, pops and replacements.
+It is still a plain `NavigatorObserver`, so it works without auto_route too.
+
 ```dart
 final feedbackObserver = WiseFeedbackNavigatorObserver();
+
+// With auto_route:
+MaterialApp.router(
+  routerConfig: appRouter.config(navigatorObservers: () => [feedbackObserver]),
+);
 
 LinearFeedback(
   transport: LinearDirectTransport(token: myBotToken, teamId: myTeamId),
 
-  // Recent screens — also add feedbackObserver to MaterialApp.navigatorObservers.
+  // Recent screens — also add feedbackObserver to your router's observers.
   navigatorObserver: feedbackObserver,
 
   // Who reported it (resolved at submit time; async-friendly).

--- a/packages/wise_feedback/lib/src/metadata/metadata.dart
+++ b/packages/wise_feedback/lib/src/metadata/metadata.dart
@@ -1,0 +1,2 @@
+export 'metadata_collector.dart';
+export 'wise_feedback_navigator_observer.dart';

--- a/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
+++ b/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
@@ -1,0 +1,77 @@
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter/foundation.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Collects a map of technical context attached to every report.
+// ignore: one_member_abstracts
+abstract interface class MetadataCollector {
+  /// Gathers metadata. Implementations must never throw — partial data is
+  /// preferable to a failed submission.
+  Future<Map<String, String>> collect();
+}
+
+/// The default [MetadataCollector]: device model, OS, app version and locale.
+///
+/// Every source is read independently and guarded, so a single failure (an
+/// unsupported platform, a missing plugin in tests) drops only that key.
+class DeviceMetadataCollector implements MetadataCollector {
+  /// Creates the collector. Inject [deviceInfo] / [packageInfoLoader] in tests.
+  DeviceMetadataCollector({
+    DeviceInfoPlugin? deviceInfo,
+    Future<PackageInfo> Function()? packageInfoLoader,
+  })  : _deviceInfo = deviceInfo ?? DeviceInfoPlugin(),
+        _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform;
+
+  final DeviceInfoPlugin _deviceInfo;
+  final Future<PackageInfo> Function() _packageInfoLoader;
+
+  @override
+  Future<Map<String, String>> collect() async {
+    final metadata = <String, String>{};
+
+    metadata['platform'] = defaultTargetPlatform.name;
+
+    try {
+      metadata['locale'] = PlatformDispatcher.instance.locale.toLanguageTag();
+    } on Object {
+      // Locale unavailable; skip.
+    }
+
+    try {
+      final info = await _packageInfoLoader();
+      metadata['appVersion'] = info.version;
+      metadata['buildNumber'] = info.buildNumber;
+    } on Object {
+      // Package info unavailable (e.g. no platform channel); skip.
+    }
+
+    await _collectDeviceInfo(metadata);
+
+    return metadata;
+  }
+
+  Future<void> _collectDeviceInfo(Map<String, String> metadata) async {
+    try {
+      switch (defaultTargetPlatform) {
+        case TargetPlatform.android:
+          final info = await _deviceInfo.androidInfo;
+          metadata['device'] = '${info.manufacturer} ${info.model}';
+          metadata['osVersion'] = 'Android ${info.version.release}';
+        case TargetPlatform.iOS:
+          final info = await _deviceInfo.iosInfo;
+          metadata['device'] = info.utsname.machine;
+          metadata['osVersion'] = '${info.systemName} ${info.systemVersion}';
+        case TargetPlatform.macOS:
+          final info = await _deviceInfo.macOsInfo;
+          metadata['device'] = info.model;
+          metadata['osVersion'] = 'macOS ${info.osRelease}';
+        // ignore: no_default_cases
+        default:
+          // Other platforms: platform name already captured above.
+          break;
+      }
+    } on Object {
+      // Device info unavailable; skip.
+    }
+  }
+}

--- a/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
+++ b/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
@@ -19,8 +19,8 @@ class DeviceMetadataCollector implements MetadataCollector {
   DeviceMetadataCollector({
     DeviceInfoPlugin? deviceInfo,
     Future<PackageInfo> Function()? packageInfoLoader,
-  })  : _deviceInfo = deviceInfo ?? DeviceInfoPlugin(),
-        _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform;
+  }) : _deviceInfo = deviceInfo ?? DeviceInfoPlugin(),
+       _packageInfoLoader = packageInfoLoader ?? PackageInfo.fromPlatform;
 
   final DeviceInfoPlugin _deviceInfo;
   final Future<PackageInfo> Function() _packageInfoLoader;

--- a/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
+++ b/packages/wise_feedback/lib/src/metadata/metadata_collector.dart
@@ -33,7 +33,7 @@ class DeviceMetadataCollector implements MetadataCollector {
 
     try {
       metadata['locale'] = PlatformDispatcher.instance.locale.toLanguageTag();
-    } on Object {
+    } catch (_) {
       // Locale unavailable; skip.
     }
 
@@ -41,7 +41,7 @@ class DeviceMetadataCollector implements MetadataCollector {
       final info = await _packageInfoLoader();
       metadata['appVersion'] = info.version;
       metadata['buildNumber'] = info.buildNumber;
-    } on Object {
+    } catch (_) {
       // Package info unavailable (e.g. no platform channel); skip.
     }
 
@@ -70,7 +70,7 @@ class DeviceMetadataCollector implements MetadataCollector {
           // Other platforms: platform name already captured above.
           break;
       }
-    } on Object {
+    } catch (_) {
       // Device info unavailable; skip.
     }
   }

--- a/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
+++ b/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+
+/// A [NavigatorObserver] that records a breadcrumb of recently visited routes.
+///
+/// Add it to your app's `navigatorObservers` and pass the same instance to
+/// `LinearFeedback(navigatorObserver: ...)`. The trail is attached to reports
+/// so triagers can see where the user was.
+class WiseFeedbackNavigatorObserver extends NavigatorObserver {
+  /// Creates the observer, keeping at most [maxEntries] recent route names.
+  WiseFeedbackNavigatorObserver({this.maxEntries = 20})
+      : assert(maxEntries > 0, 'maxEntries must be positive');
+
+  /// The maximum number of route names retained (oldest dropped first).
+  final int maxEntries;
+
+  final List<String> _breadcrumbs = <String>[];
+
+  /// The recorded route names, oldest first.
+  List<String> get breadcrumbs => List<String>.unmodifiable(_breadcrumbs);
+
+  void _record(Route<dynamic>? route) {
+    final name = route?.settings.name;
+    if (name == null || name.isEmpty) {
+      return;
+    }
+    _breadcrumbs.add(name);
+    if (_breadcrumbs.length > maxEntries) {
+      _breadcrumbs.removeAt(0);
+    }
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _record(route);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    _record(newRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _record(previousRoute);
+  }
+}

--- a/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
+++ b/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
@@ -8,7 +8,7 @@ import 'package:flutter/widgets.dart';
 class WiseFeedbackNavigatorObserver extends NavigatorObserver {
   /// Creates the observer, keeping at most [maxEntries] recent route names.
   WiseFeedbackNavigatorObserver({this.maxEntries = 20})
-      : assert(maxEntries > 0, 'maxEntries must be positive');
+    : assert(maxEntries > 0, 'maxEntries must be positive');
 
   /// The maximum number of route names retained (oldest dropped first).
   final int maxEntries;

--- a/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
+++ b/packages/wise_feedback/lib/src/metadata/wise_feedback_navigator_observer.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 
 /// A [NavigatorObserver] that records a breadcrumb of recently visited routes.
@@ -5,7 +6,12 @@ import 'package:flutter/widgets.dart';
 /// Add it to your app's `navigatorObservers` and pass the same instance to
 /// `LinearFeedback(navigatorObserver: ...)`. The trail is attached to reports
 /// so triagers can see where the user was.
-class WiseFeedbackNavigatorObserver extends NavigatorObserver {
+///
+/// It extends auto_route's [AutoRouterObserver], so tab switches (bottom bar
+/// or tab bar taps inside an `AutoTabsRouter`) are recorded alongside pushes,
+/// pops and replacements. On a plain [Navigator] it behaves like any other
+/// [NavigatorObserver].
+class WiseFeedbackNavigatorObserver extends AutoRouterObserver {
   /// Creates the observer, keeping at most [maxEntries] recent route names.
   WiseFeedbackNavigatorObserver({this.maxEntries = 20})
     : assert(maxEntries > 0, 'maxEntries must be positive');
@@ -18,8 +24,9 @@ class WiseFeedbackNavigatorObserver extends NavigatorObserver {
   /// The recorded route names, oldest first.
   List<String> get breadcrumbs => List<String>.unmodifiable(_breadcrumbs);
 
-  void _record(Route<dynamic>? route) {
-    final name = route?.settings.name;
+  void _record(Route<dynamic>? route) => _add(route?.settings.name);
+
+  void _add(String? name) {
     if (name == null || name.isEmpty) {
       return;
     }
@@ -42,5 +49,23 @@ class WiseFeedbackNavigatorObserver extends NavigatorObserver {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     _record(previousRoute);
+  }
+
+  /// Records a tab the user activated for the first time.
+  ///
+  /// A null [previousRoute] means the tab was built without the user moving to
+  /// it — the initially active tab, or a sibling eagerly built by an
+  /// `AutoTabsRouter` with `lazyLoad: false` — so it is not a breadcrumb.
+  @override
+  void didInitTabRoute(TabPageRoute route, TabPageRoute? previousRoute) {
+    if (previousRoute == null) {
+      return;
+    }
+    _add(route.name);
+  }
+
+  @override
+  void didChangeTabRoute(TabPageRoute route, TabPageRoute previousRoute) {
+    _add(route.name);
   }
 }

--- a/packages/wise_feedback/lib/src/models/feedback_priority.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_priority.dart
@@ -1,0 +1,27 @@
+/// Severity the reporter assigned to a report.
+///
+/// [linearValue] maps to Linear's native issue priority scale.
+enum FeedbackPriority {
+  /// No priority set (Linear `0`).
+  none(0, 'None'),
+
+  /// Urgent (Linear `1`).
+  urgent(1, 'Urgent'),
+
+  /// High (Linear `2`).
+  high(2, 'High'),
+
+  /// Medium (Linear `3`).
+  medium(3, 'Medium'),
+
+  /// Low (Linear `4`).
+  low(4, 'Low');
+
+  const FeedbackPriority(this.linearValue, this.label);
+
+  /// The value understood by Linear's `issueCreate` `priority` input.
+  final int linearValue;
+
+  /// Human-readable label shown in the form and rendered into the issue.
+  final String label;
+}

--- a/packages/wise_feedback/lib/src/models/feedback_priority.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_priority.dart
@@ -15,7 +15,8 @@ enum FeedbackPriority {
   medium(3, 'Medium'),
 
   /// Low (Linear `4`).
-  low(4, 'Low');
+  low(4, 'Low'),
+  ;
 
   const FeedbackPriority(this.linearValue, this.label);
 

--- a/packages/wise_feedback/lib/src/models/feedback_report.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_report.dart
@@ -1,13 +1,20 @@
 import 'dart:typed_data';
 
+import 'feedback_priority.dart';
+import 'feedback_reporter.dart';
+
 /// An immutable bug report captured from the app.
 class FeedbackReport {
-  /// Creates a report. [metadata] defaults to an empty, unmodifiable map.
+  /// Creates a report. [metadata] defaults to an empty, unmodifiable map and
+  /// [priority] defaults to [FeedbackPriority.none].
   const FeedbackReport({
     required this.title,
     required this.description,
     required this.screenshotPng,
     this.metadata = const {},
+    this.reporter,
+    this.priority = FeedbackPriority.none,
+    this.category,
   });
 
   /// Short summary of the issue.
@@ -21,4 +28,13 @@ class FeedbackReport {
 
   /// Open extension bag for forward-compatible metadata (device, route, ...).
   final Map<String, Object?> metadata;
+
+  /// Who submitted the report, if known.
+  final FeedbackReporter? reporter;
+
+  /// Severity the reporter assigned.
+  final FeedbackPriority priority;
+
+  /// Optional free-form category (e.g. `Bug`, `Idea`).
+  final String? category;
 }

--- a/packages/wise_feedback/lib/src/models/feedback_report.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_report.dart
@@ -17,6 +17,12 @@ class FeedbackReport {
     this.category,
   });
 
+  /// [metadata] key under which the navigation breadcrumb is stored.
+  ///
+  /// Transports read this key to render the trail separately from the rest of
+  /// the environment, so producers and consumers must agree on it.
+  static const String navigationKey = 'navigation';
+
   /// Short summary of the issue.
   final String title;
 

--- a/packages/wise_feedback/lib/src/models/feedback_reporter.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_reporter.dart
@@ -1,0 +1,20 @@
+/// Identifies who submitted a report.
+///
+/// All fields are optional; supply whatever your app knows about the current
+/// user. Attached to the report so triagers can follow up.
+class FeedbackReporter {
+  /// Creates a reporter. Any field may be null.
+  const FeedbackReporter({this.id, this.name, this.email});
+
+  /// Stable user identifier, if available.
+  final String? id;
+
+  /// Display name, if available.
+  final String? name;
+
+  /// Contact email, if available.
+  final String? email;
+
+  /// Whether no identifying information was provided.
+  bool get isEmpty => id == null && name == null && email == null;
+}

--- a/packages/wise_feedback/lib/src/models/models.dart
+++ b/packages/wise_feedback/lib/src/models/models.dart
@@ -1,4 +1,6 @@
 export 'feedback_exception.dart';
+export 'feedback_priority.dart';
 export 'feedback_report.dart';
+export 'feedback_reporter.dart';
 export 'feedback_result.dart';
 export 'feedback_status.dart';

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -164,7 +164,10 @@ class _FeedbackFormState extends State<FeedbackForm> {
                     ),
                     items: [
                       for (final category in categories)
-                        DropdownMenuItem(value: category, child: Text(category)),
+                        DropdownMenuItem(
+                          value: category,
+                          child: Text(category),
+                        ),
                     ],
                     onChanged: (value) => setState(() => _category = value),
                   ),

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../models/feedback_priority.dart';
 import '../models/feedback_status.dart';
 import '../theme/wise_feedback_theme.dart';
 
@@ -32,10 +33,15 @@ class FeedbackForm extends StatefulWidget {
     required this.theme,
     required this.status,
     this.scrollController,
+    this.showPriority = false,
+    this.categories,
     super.key,
   });
 
-  /// Called with the description and `{'title': ...}` extras on submit.
+  /// Called with the description and extras on submit.
+  ///
+  /// The extras map carries `title`, and — when the respective field is shown —
+  /// `priority` (a [FeedbackPriority] name) and `category`.
   final FeedbackFormSubmit onSubmit;
 
   /// Visual configuration.
@@ -51,6 +57,12 @@ class FeedbackForm extends StatefulWidget {
   /// is short or the keyboard is open.
   final ScrollController? scrollController;
 
+  /// Whether to show a priority selector.
+  final bool showPriority;
+
+  /// Category options to offer, or null to hide the category selector.
+  final List<String>? categories;
+
   @override
   State<FeedbackForm> createState() => _FeedbackFormState();
 }
@@ -58,6 +70,8 @@ class FeedbackForm extends StatefulWidget {
 class _FeedbackFormState extends State<FeedbackForm> {
   final _titleController = TextEditingController();
   final _descriptionController = TextEditingController();
+  FeedbackPriority _priority = FeedbackPriority.none;
+  String? _category;
 
   @override
   void dispose() {
@@ -71,7 +85,11 @@ class _FeedbackFormState extends State<FeedbackForm> {
     // reflected through `status`, so nothing here has to change local state.
     await widget.onSubmit(
       _descriptionController.text,
-      extras: {'title': _titleController.text},
+      extras: <String, dynamic>{
+        'title': _titleController.text,
+        if (widget.showPriority) 'priority': _priority.name,
+        if (_category != null) 'category': _category,
+      },
     );
   }
 
@@ -117,6 +135,39 @@ class _FeedbackFormState extends State<FeedbackForm> {
                     border: const OutlineInputBorder(),
                   ),
                 ),
+                if (widget.showPriority)
+                  DropdownButtonFormField<FeedbackPriority>(
+                    key: const Key('wise_feedback_priority'),
+                    initialValue: _priority,
+                    decoration: InputDecoration(
+                      labelText: theme.priorityLabel,
+                      border: const OutlineInputBorder(),
+                    ),
+                    items: [
+                      for (final priority in FeedbackPriority.values)
+                        DropdownMenuItem(
+                          value: priority,
+                          child: Text(priority.label),
+                        ),
+                    ],
+                    onChanged: (value) => setState(
+                      () => _priority = value ?? FeedbackPriority.none,
+                    ),
+                  ),
+                if (widget.categories case final List<String> categories)
+                  DropdownButtonFormField<String>(
+                    key: const Key('wise_feedback_category'),
+                    initialValue: _category,
+                    decoration: InputDecoration(
+                      labelText: theme.categoryLabel,
+                      border: const OutlineInputBorder(),
+                    ),
+                    items: [
+                      for (final category in categories)
+                        DropdownMenuItem(value: category, child: Text(category)),
+                    ],
+                    onChanged: (value) => setState(() => _category = value),
+                  ),
                 if (errorText != null)
                   Row(
                     key: const Key('wise_feedback_error'),

--- a/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
+++ b/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
@@ -14,6 +14,8 @@ class WiseFeedbackTheme {
     this.titleHint = 'Title',
     this.descriptionHint = 'Description',
     this.submitLabel = 'Report bug',
+    this.priorityLabel = 'Priority',
+    this.categoryLabel = 'Category',
     this.successMessage = 'Bug reported. Thanks!',
     this.genericErrorMessage = 'Something went wrong. Please try again.',
   });
@@ -29,6 +31,12 @@ class WiseFeedbackTheme {
 
   /// Text on the submit button.
   final String submitLabel;
+
+  /// Label for the priority selector.
+  final String priorityLabel;
+
+  /// Label for the category selector.
+  final String categoryLabel;
 
   /// Confirmation shown after a report is filed successfully.
   final String successMessage;

--- a/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
+++ b/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/feedback_exception.dart';
+import '../models/feedback_priority.dart';
 import '../models/feedback_report.dart';
 import '../models/feedback_result.dart';
 import 'feedback_transport.dart';
@@ -49,8 +50,8 @@ mutation FileUpload($contentType: String!, $filename: String!, $size: Int!) {
 ''';
 
   static const String _issueCreateMutation = r'''
-mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $projectId: String) {
-  issueCreate(input: {title: $title, description: $description, teamId: $teamId, projectId: $projectId}) {
+mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $projectId: String, $priority: Int) {
+  issueCreate(input: {title: $title, description: $description, teamId: $teamId, projectId: $projectId, priority: $priority}) {
     success
     issue { id url }
   }
@@ -114,12 +115,12 @@ mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $
     FeedbackReport report,
     String assetUrl,
   ) async {
-    final description = '${report.description}\n\n![screenshot]($assetUrl)';
     final data = await _graphql(_issueCreateMutation, <String, dynamic>{
       'title': report.title,
-      'description': description,
+      'description': _renderBody(report, assetUrl),
       'teamId': _teamId,
       'projectId': _projectId,
+      'priority': report.priority.linearValue,
     });
     final issueCreate = data['issueCreate'] as Json?;
     final success = issueCreate?['success'] as bool?;
@@ -131,6 +132,53 @@ mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $
       issueId: issue['id'] as String?,
       issueUrl: issue['url'] as String?,
     );
+  }
+
+  /// Builds the issue body: the user's text, a `## Context` section rendering
+  /// reporter/category/priority/environment/navigation, then the screenshot.
+  String _renderBody(FeedbackReport report, String assetUrl) {
+    final buffer = StringBuffer(report.description);
+    final context = <String>[];
+
+    final reporter = report.reporter;
+    if (reporter != null && !reporter.isEmpty) {
+      final named = <String?>[reporter.name, reporter.email]
+          .whereType<String>()
+          .where((value) => value.isNotEmpty)
+          .toList();
+      final who = named.isNotEmpty ? named.join(' · ') : (reporter.id ?? '');
+      if (who.isNotEmpty) {
+        context.add('**Reported by:** $who');
+      }
+    }
+    if (report.category case final String category) {
+      context.add('**Category:** $category');
+    }
+    if (report.priority != FeedbackPriority.none) {
+      context.add('**Priority:** ${report.priority.label}');
+    }
+
+    final environment = report.metadata.entries
+        .where((entry) => entry.key != 'navigation')
+        .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
+        .toList();
+    final navigation = report.metadata['navigation'];
+
+    if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
+      buffer.write('\n\n## Context\n');
+      if (context.isNotEmpty) {
+        buffer.write('${context.join('\n')}\n');
+      }
+      if (environment.isNotEmpty) {
+        buffer.write('\n**Environment**\n${environment.join('\n')}\n');
+      }
+      if (navigation != null) {
+        buffer.write('\n**Recent screens:** $navigation\n');
+      }
+    }
+
+    buffer.write('\n\n![screenshot]($assetUrl)');
+    return buffer.toString();
   }
 
   Future<Json> _graphql(

--- a/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
+++ b/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
@@ -159,10 +159,10 @@ mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $
     }
 
     final environment = report.metadata.entries
-        .where((entry) => entry.key != 'navigation')
+        .where((entry) => entry.key != FeedbackReport.navigationKey)
         .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
         .toList();
-    final navigation = report.metadata['navigation'];
+    final navigation = report.metadata[FeedbackReport.navigationKey];
 
     if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
       buffer.write('\n\n## Context\n');

--- a/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
+++ b/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
@@ -142,10 +142,10 @@ mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $
 
     final reporter = report.reporter;
     if (reporter != null && !reporter.isEmpty) {
-      final named = <String?>[reporter.name, reporter.email]
-          .whereType<String>()
-          .where((value) => value.isNotEmpty)
-          .toList();
+      final named = <String?>[
+        reporter.name,
+        reporter.email,
+      ].whereType<String>().where((value) => value.isNotEmpty).toList();
       final who = named.isNotEmpty ? named.join(' · ') : (reporter.id ?? '');
       if (who.isNotEmpty) {
         context.add('**Reported by:** $who');

--- a/packages/wise_feedback/lib/src/transport/linear_proxy_transport.dart
+++ b/packages/wise_feedback/lib/src/transport/linear_proxy_transport.dart
@@ -19,7 +19,8 @@ typedef AuthHeadersProvider = Future<Map<String, String>> Function();
 /// app's own auth via `authHeadersProvider`.
 ///
 /// Request: `multipart/form-data` with `title`, `description`, `metadata`
-/// (JSON string) fields and a `screenshot` (image/png) file part.
+/// (JSON string), `priority` (int), and — when set — `category` and `reporter`
+/// (JSON) fields, plus a `screenshot` (image/png) file part.
 /// Response: 2xx JSON `{ "issueId": "...", "issueUrl": "..." }`.
 class LinearProxyTransport implements FeedbackTransport {
   /// Creates a proxy transport targeting [endpoint].
@@ -37,10 +38,12 @@ class LinearProxyTransport implements FeedbackTransport {
 
   @override
   Future<FeedbackResult> send(FeedbackReport report) async {
+    final reporter = report.reporter;
     final request = http.MultipartRequest('POST', _endpoint)
       ..fields['title'] = report.title
       ..fields['description'] = report.description
       ..fields['metadata'] = jsonEncode(report.metadata)
+      ..fields['priority'] = report.priority.linearValue.toString()
       ..files.add(
         http.MultipartFile.fromBytes(
           'screenshot',
@@ -48,6 +51,16 @@ class LinearProxyTransport implements FeedbackTransport {
           filename: 'feedback.png',
         ),
       );
+    if (report.category case final String category) {
+      request.fields['category'] = category;
+    }
+    if (reporter != null && !reporter.isEmpty) {
+      request.fields['reporter'] = jsonEncode(<String, String?>{
+        'id': reporter.id,
+        'name': reporter.name,
+        'email': reporter.email,
+      });
+    }
 
     if (_authHeadersProvider != null) {
       final Map<String, String> authHeaders;

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -180,7 +180,8 @@ class _LinearFeedbackState extends State<LinearFeedback> {
   Future<Map<String, Object?>> _collectMetadata() async {
     final metadata = <String, Object?>{};
 
-    final collector = widget.metadataCollector ??
+    final collector =
+        widget.metadataCollector ??
         (widget.collectDeviceInfo ? _defaultCollector : null);
     if (collector != null) {
       final collected = await _guard(collector.collect);

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -4,8 +4,12 @@ import 'package:feedback/feedback.dart' hide FeedbackController;
 import 'package:flutter/material.dart';
 
 import '../controller/feedback_controller.dart';
+import '../metadata/metadata_collector.dart';
+import '../metadata/wise_feedback_navigator_observer.dart';
 import '../models/feedback_exception.dart';
+import '../models/feedback_priority.dart';
 import '../models/feedback_report.dart';
+import '../models/feedback_reporter.dart';
 import '../models/feedback_status.dart';
 import '../screens/feedback_form.dart';
 import '../theme/wise_feedback_theme.dart';
@@ -28,6 +32,13 @@ class LinearFeedback extends StatefulWidget {
     this.showButton = true,
     this.buttonAlignment = Alignment.bottomRight,
     this.buttonBackgroundColor = Colors.black,
+    this.collectDeviceInfo = true,
+    this.metadataCollector,
+    this.navigatorObserver,
+    this.reporter,
+    this.metadataBuilder,
+    this.showPriority = true,
+    this.categories,
     super.key,
   });
 
@@ -52,6 +63,30 @@ class LinearFeedback extends StatefulWidget {
   /// Background color of the built-in button.
   final Color buttonBackgroundColor;
 
+  /// Whether to attach automatic device/app/OS metadata to each report.
+  final bool collectDeviceInfo;
+
+  /// Overrides the metadata collector. Defaults to [DeviceMetadataCollector]
+  /// when [collectDeviceInfo] is true.
+  final MetadataCollector? metadataCollector;
+
+  /// The navigation observer whose breadcrumb trail is attached to reports.
+  ///
+  /// Add the same instance to your app's `navigatorObservers`.
+  final WiseFeedbackNavigatorObserver? navigatorObserver;
+
+  /// Resolves the current reporter (e.g. the signed-in user) at submit time.
+  final FutureOr<FeedbackReporter?> Function()? reporter;
+
+  /// Supplies extra custom metadata (feature flags, tenant, ...) at submit time.
+  final FutureOr<Map<String, String>> Function()? metadataBuilder;
+
+  /// Whether the form shows a priority selector. Defaults to true.
+  final bool showPriority;
+
+  /// Category options to offer in the form, or null to hide the selector.
+  final List<String>? categories;
+
   @override
   State<LinearFeedback> createState() => _LinearFeedbackState();
 }
@@ -61,6 +96,8 @@ class _LinearFeedbackState extends State<LinearFeedback> {
     widget.transport,
   );
   final FeedbackToastPresenter _toasts = FeedbackToastPresenter();
+  late final DeviceMetadataCollector _defaultCollector =
+      DeviceMetadataCollector();
 
   BuildContext? _overlayContext;
   Listenable? _feedbackNotifier;
@@ -106,12 +143,18 @@ class _LinearFeedbackState extends State<LinearFeedback> {
   }
 
   Future<void> _handleUserFeedback(UserFeedback feedback) async {
-    final title = (feedback.extra?['title'] as String?) ?? '';
+    final extra = feedback.extra ?? const <String, dynamic>{};
+    final metadata = await _collectMetadata();
+    final reporter = await _resolveReporter();
     await _controller.submit(
       FeedbackReport(
-        title: title,
+        title: (extra['title'] as String?) ?? '',
         description: feedback.text,
         screenshotPng: feedback.screenshot,
+        metadata: metadata,
+        reporter: reporter,
+        priority: _priorityFromName(extra['priority'] as String?),
+        category: extra['category'] as String?,
       ),
     );
     final status = _controller.value;
@@ -122,6 +165,62 @@ class _LinearFeedbackState extends State<LinearFeedback> {
       }
       throw FeedbackException('Failed to send the report.', cause: error);
     }
+  }
+
+  /// Runs [body], swallowing any error (metadata collection must never block a
+  /// submission).
+  Future<T?> _guard<T>(Future<T> Function() body) async {
+    try {
+      return await body();
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<Map<String, Object?>> _collectMetadata() async {
+    final metadata = <String, Object?>{};
+
+    final collector = widget.metadataCollector ??
+        (widget.collectDeviceInfo ? _defaultCollector : null);
+    if (collector != null) {
+      final collected = await _guard(collector.collect);
+      if (collected != null) {
+        metadata.addAll(collected);
+      }
+    }
+
+    final builder = widget.metadataBuilder;
+    if (builder != null) {
+      final custom = await _guard(() async => builder());
+      if (custom != null) {
+        metadata.addAll(custom);
+      }
+    }
+
+    final observer = widget.navigatorObserver;
+    if (observer != null && observer.breadcrumbs.isNotEmpty) {
+      metadata['navigation'] = observer.breadcrumbs.join(' → ');
+    }
+
+    return metadata;
+  }
+
+  Future<FeedbackReporter?> _resolveReporter() async {
+    final builder = widget.reporter;
+    if (builder == null) {
+      return null;
+    }
+    return _guard<FeedbackReporter?>(() async => builder());
+  }
+
+  FeedbackPriority _priorityFromName(String? name) {
+    if (name == null) {
+      return FeedbackPriority.none;
+    }
+    return FeedbackPriority.values.firstWhere(
+      (priority) => priority.name == name,
+      orElse: () => FeedbackPriority.none,
+    );
   }
 
   Future<void> _submit(
@@ -152,6 +251,8 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         theme: widget.theme,
         status: _controller,
         scrollController: scrollController,
+        showPriority: widget.showPriority,
+        categories: widget.categories,
         onSubmit: (description, {extras}) =>
             _submit(onSubmit, description, extras),
       ),

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -17,6 +17,12 @@ import '../transport/feedback_transport.dart';
 import 'feedback_button.dart';
 import 'feedback_toast.dart';
 
+/// Resolves the current reporter at submit time, or null when unknown.
+typedef FeedbackReporterResolver = FutureOr<FeedbackReporter?> Function();
+
+/// Supplies extra custom metadata at submit time.
+typedef FeedbackMetadataBuilder = FutureOr<Map<String, String>> Function();
+
 /// Mount once near the app root to enable in-app bug reporting.
 ///
 /// Wraps [child] with the screenshot capture layer, overlays a built-in
@@ -32,7 +38,6 @@ class LinearFeedback extends StatefulWidget {
     this.showButton = true,
     this.buttonAlignment = Alignment.bottomRight,
     this.buttonBackgroundColor = Colors.black,
-    this.collectDeviceInfo = true,
     this.metadataCollector,
     this.navigatorObserver,
     this.reporter,
@@ -63,11 +68,10 @@ class LinearFeedback extends StatefulWidget {
   /// Background color of the built-in button.
   final Color buttonBackgroundColor;
 
-  /// Whether to attach automatic device/app/OS metadata to each report.
-  final bool collectDeviceInfo;
-
-  /// Overrides the metadata collector. Defaults to [DeviceMetadataCollector]
-  /// when [collectDeviceInfo] is true.
+  /// Collects the technical context attached to each report.
+  ///
+  /// Defaults to [DeviceMetadataCollector] (device, OS, app version, locale).
+  /// Pass a collector returning an empty map to attach nothing.
   final MetadataCollector? metadataCollector;
 
   /// The navigation observer whose breadcrumb trail is attached to reports.
@@ -76,10 +80,10 @@ class LinearFeedback extends StatefulWidget {
   final WiseFeedbackNavigatorObserver? navigatorObserver;
 
   /// Resolves the current reporter (e.g. the signed-in user) at submit time.
-  final FutureOr<FeedbackReporter?> Function()? reporter;
+  final FeedbackReporterResolver? reporter;
 
   /// Supplies extra custom metadata (feature flags, tenant, ...) at submit time.
-  final FutureOr<Map<String, String>> Function()? metadataBuilder;
+  final FeedbackMetadataBuilder? metadataBuilder;
 
   /// Whether the form shows a priority selector. Defaults to true.
   final bool showPriority;
@@ -180,14 +184,10 @@ class _LinearFeedbackState extends State<LinearFeedback> {
   Future<Map<String, Object?>> _collectMetadata() async {
     final metadata = <String, Object?>{};
 
-    final collector =
-        widget.metadataCollector ??
-        (widget.collectDeviceInfo ? _defaultCollector : null);
-    if (collector != null) {
-      final collected = await _guard(collector.collect);
-      if (collected != null) {
-        metadata.addAll(collected);
-      }
+    final collector = widget.metadataCollector ?? _defaultCollector;
+    final collected = await _guard(collector.collect);
+    if (collected != null) {
+      metadata.addAll(collected);
     }
 
     final builder = widget.metadataBuilder;
@@ -200,7 +200,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
 
     final observer = widget.navigatorObserver;
     if (observer != null && observer.breadcrumbs.isNotEmpty) {
-      metadata['navigation'] = observer.breadcrumbs.join(' → ');
+      metadata[FeedbackReport.navigationKey] = observer.breadcrumbs.join(' → ');
     }
 
     return metadata;

--- a/packages/wise_feedback/lib/wise_feedback.dart
+++ b/packages/wise_feedback/lib/wise_feedback.dart
@@ -1,6 +1,7 @@
 /// In-app bug reporting for Flutter that files reports as Linear issues.
 library wise_feedback;
 
+export 'src/metadata/metadata.dart';
 export 'src/models/models.dart';
 export 'src/screens/screens.dart';
 export 'src/theme/theme.dart';

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -16,6 +16,9 @@ dependencies:
   feedback: ">=3.2.0 <4.0.0"
   # Transport HTTP + GraphQL-over-HTTP
   http: ">=1.2.0 <2.0.0"
+  # Automatic report metadata
+  device_info_plus: ">=11.0.0 <14.0.0"
+  package_info_plus: ">=8.0.0 <11.0.0"
 
 dev_dependencies:
   # Static analysis & linting

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wise_feedback
 description: In-app bug reporting for Flutter that files a screenshot, title and description as a Linear issue, via a pluggable transport (direct token or backend proxy).
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 repository: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -12,6 +12,8 @@ dependencies:
   # Flutter
   flutter:
     sdk: flutter
+  # Route breadcrumbs, including tab (bottom bar) switches
+  auto_route: ">=11.0.0 <12.0.0"
   # Screenshot capture + feedback overlay
   feedback: ">=3.2.0 <4.0.0"
   # Transport HTTP + GraphQL-over-HTTP

--- a/packages/wise_feedback/test/metadata/metadata_collector_test.dart
+++ b/packages/wise_feedback/test/metadata/metadata_collector_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:wise_feedback/wise_feedback.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DeviceMetadataCollector', () {
+    test('includes platform and app version, and never throws', () async {
+      final collector = DeviceMetadataCollector(
+        packageInfoLoader: () async => PackageInfo(
+          appName: 'Demo',
+          packageName: 'com.demo',
+          version: '1.2.3',
+          buildNumber: '45',
+        ),
+      );
+
+      final metadata = await collector.collect();
+
+      expect(metadata['platform'], isNotEmpty);
+      expect(metadata['appVersion'], '1.2.3');
+      expect(metadata['buildNumber'], '45');
+    });
+
+    test('returns partial data when a source fails', () async {
+      final collector = DeviceMetadataCollector(
+        packageInfoLoader: () async => throw Exception('no channel'),
+      );
+
+      // Device info channels are also absent in tests; collect() must still
+      // return the platform key without throwing.
+      final metadata = await collector.collect();
+
+      expect(metadata['platform'], isNotEmpty);
+      expect(metadata.containsKey('appVersion'), isFalse);
+    });
+  });
+}

--- a/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
+++ b/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wise_feedback/wise_feedback.dart';
+
+Route<void> _route(String name) => PageRouteBuilder<void>(
+      settings: RouteSettings(name: name),
+      pageBuilder: (_, __, ___) => const SizedBox(),
+    );
+
+void main() {
+  group('WiseFeedbackNavigatorObserver', () {
+    test('records pushed route names in order', () {
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didPush(_route('a'), null)
+        ..didPush(_route('b'), null)
+        ..didPush(_route('c'), null);
+      expect(observer.breadcrumbs, ['a', 'b', 'c']);
+    });
+
+    test('drops the oldest entry beyond maxEntries', () {
+      final observer = WiseFeedbackNavigatorObserver(maxEntries: 2)
+        ..didPush(_route('a'), null)
+        ..didPush(_route('b'), null)
+        ..didPush(_route('c'), null);
+      expect(observer.breadcrumbs, ['b', 'c']);
+    });
+
+    test('ignores routes without a name', () {
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didPush(_route(''), null);
+      expect(observer.breadcrumbs, isEmpty);
+    });
+  });
+}

--- a/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
+++ b/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
@@ -3,9 +3,9 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:wise_feedback/wise_feedback.dart';
 
 Route<void> _route(String name) => PageRouteBuilder<void>(
-      settings: RouteSettings(name: name),
-      pageBuilder: (_, __, ___) => const SizedBox(),
-    );
+  settings: RouteSettings(name: name),
+  pageBuilder: (_, __, ___) => const SizedBox(),
+);
 
 void main() {
   group('WiseFeedbackNavigatorObserver', () {

--- a/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
+++ b/packages/wise_feedback/test/metadata/wise_feedback_navigator_observer_test.dart
@@ -1,3 +1,4 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wise_feedback/wise_feedback.dart';
@@ -5,6 +6,16 @@ import 'package:wise_feedback/wise_feedback.dart';
 Route<void> _route(String name) => PageRouteBuilder<void>(
   settings: RouteSettings(name: name),
   pageBuilder: (_, __, ___) => const SizedBox(),
+);
+
+TabPageRoute _tab(String name, int index) => TabPageRoute(
+  routeInfo: RouteMatch(
+    config: AutoRoute(page: PageInfo.emptyShell(name), path: name),
+    segments: <String>[name],
+    stringMatch: name,
+    key: ValueKey<String>(name),
+  ),
+  index: index,
 );
 
 void main() {
@@ -28,6 +39,29 @@ void main() {
     test('ignores routes without a name', () {
       final observer = WiseFeedbackNavigatorObserver()
         ..didPush(_route(''), null);
+      expect(observer.breadcrumbs, isEmpty);
+    });
+
+    test('records tab switches alongside pushes', () {
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didPush(_route('home'), null)
+        ..didChangeTabRoute(_tab('SettingsRoute', 1), _tab('HomeRoute', 0));
+      expect(observer.breadcrumbs, ['home', 'SettingsRoute']);
+    });
+
+    test('records a tab activated for the first time', () {
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didInitTabRoute(
+          _tab('SettingsRoute', 1),
+          _tab('HomeRoute', 0),
+        );
+      expect(observer.breadcrumbs, ['SettingsRoute']);
+    });
+
+    test('ignores tabs built without the user moving to them', () {
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didInitTabRoute(_tab('HomeRoute', 0), null)
+        ..didInitTabRoute(_tab('SettingsRoute', 1), null);
       expect(observer.breadcrumbs, isEmpty);
     });
   });

--- a/packages/wise_feedback/test/models/feedback_priority_test.dart
+++ b/packages/wise_feedback/test/models/feedback_priority_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wise_feedback/wise_feedback.dart';
+
+void main() {
+  group('FeedbackPriority', () {
+    test('maps to the Linear priority scale', () {
+      expect(FeedbackPriority.none.linearValue, 0);
+      expect(FeedbackPriority.urgent.linearValue, 1);
+      expect(FeedbackPriority.high.linearValue, 2);
+      expect(FeedbackPriority.medium.linearValue, 3);
+      expect(FeedbackPriority.low.linearValue, 4);
+    });
+
+    test('exposes a human-readable label', () {
+      expect(FeedbackPriority.high.label, 'High');
+    });
+  });
+
+  group('FeedbackReporter', () {
+    test('isEmpty reflects whether any field is set', () {
+      expect(const FeedbackReporter().isEmpty, isTrue);
+      expect(const FeedbackReporter(email: 'a@b.c').isEmpty, isFalse);
+      expect(const FeedbackReporter(name: 'Ann').isEmpty, isFalse);
+    });
+  });
+}

--- a/packages/wise_feedback/test/models/feedback_report_test.dart
+++ b/packages/wise_feedback/test/models/feedback_report_test.dart
@@ -25,5 +25,30 @@ void main() {
       );
       expect(report.metadata['route'], '/home');
     });
+
+    test('reporter, priority and category default to empty/none', () {
+      final report = FeedbackReport(
+        title: 't',
+        description: 'd',
+        screenshotPng: Uint8List(0),
+      );
+      expect(report.reporter, isNull);
+      expect(report.priority, FeedbackPriority.none);
+      expect(report.category, isNull);
+    });
+
+    test('reporter, priority and category are retained when provided', () {
+      final report = FeedbackReport(
+        title: 't',
+        description: 'd',
+        screenshotPng: Uint8List(0),
+        reporter: const FeedbackReporter(email: 'a@b.c'),
+        priority: FeedbackPriority.high,
+        category: 'Bug',
+      );
+      expect(report.reporter?.email, 'a@b.c');
+      expect(report.priority, FeedbackPriority.high);
+      expect(report.category, 'Bug');
+    });
   });
 }

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -85,6 +85,62 @@ void main() {
       expect(find.byKey(const Key('wise_feedback_submit')), findsOneWidget);
     });
 
+    testWidgets('forwards selected priority and category in extras', (
+      tester,
+    ) async {
+      Map<String, dynamic>? gotExtras;
+      final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackForm(
+              theme: const WiseFeedbackTheme(),
+              status: status,
+              showPriority: true,
+              categories: const ['Bug', 'Idea'],
+              onSubmit: (description, {extras}) async {
+                gotExtras = extras;
+              },
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('wise_feedback_priority')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('High').last);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('wise_feedback_category')));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Idea').last);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(const Key('wise_feedback_submit')));
+      await tester.pump();
+
+      expect(gotExtras?['priority'], 'high');
+      expect(gotExtras?['category'], 'Idea');
+    });
+
+    testWidgets('hides priority and category by default', (tester) async {
+      final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackForm(
+              theme: const WiseFeedbackTheme(),
+              status: status,
+              onSubmit: (description, {extras}) async {},
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(const Key('wise_feedback_priority')), findsNothing);
+      expect(find.byKey(const Key('wise_feedback_category')), findsNothing);
+    });
+
     testWidgets('does not overflow in a short sheet with the keyboard open', (
       tester,
     ) async {

--- a/packages/wise_feedback/test/transport/linear_direct_transport_test.dart
+++ b/packages/wise_feedback/test/transport/linear_direct_transport_test.dart
@@ -198,5 +198,70 @@ void main() {
         throwsA(isA<FeedbackException>()),
       );
     });
+
+    test('renders context and maps priority into issueCreate', () async {
+      Map<String, dynamic>? issueVars;
+      final client = MockClient((request) async {
+        if (request.method == 'PUT') {
+          return http.Response('', 200);
+        }
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        final query = body['query'] as String;
+        if (query.contains('fileUpload')) {
+          return http.Response(
+            jsonEncode({
+              'data': {
+                'fileUpload': {
+                  'uploadFile': {
+                    'uploadUrl': 'https://uploads.example/put',
+                    'assetUrl': 'https://assets.example/a.png',
+                    'headers': <dynamic>[],
+                  },
+                },
+              },
+            }),
+            200,
+          );
+        }
+        issueVars = body['variables'] as Map<String, dynamic>;
+        return http.Response(
+          jsonEncode({
+            'data': {
+              'issueCreate': {
+                'success': true,
+                'issue': {'id': 'i', 'url': 'u'},
+              },
+            },
+          }),
+          200,
+        );
+      });
+
+      final report = FeedbackReport(
+        title: 'Bug',
+        description: 'broke',
+        screenshotPng: Uint8List.fromList([1]),
+        reporter: const FeedbackReporter(name: 'Ann', email: 'a@b.c'),
+        priority: FeedbackPriority.high,
+        category: 'Bug',
+        metadata: const {'appVersion': '1.2.3', 'navigation': '/a → /b'},
+      );
+
+      await LinearDirectTransport(
+        token: 't',
+        teamId: 'team',
+        httpClient: client,
+      ).send(report);
+
+      expect(issueVars?['priority'], FeedbackPriority.high.linearValue);
+      final description = issueVars?['description'] as String;
+      expect(description, contains('Reported by'));
+      expect(description, contains('a@b.c'));
+      expect(description, contains('**Category:** Bug'));
+      expect(description, contains('**Priority:** High'));
+      expect(description, contains('appVersion'));
+      expect(description, contains('Recent screens'));
+      expect(description, contains('/a → /b'));
+    });
   });
 }

--- a/packages/wise_feedback/test/transport/linear_proxy_transport_test.dart
+++ b/packages/wise_feedback/test/transport/linear_proxy_transport_test.dart
@@ -63,5 +63,33 @@ void main() {
         throwsA(isA<FeedbackException>()),
       );
     });
+
+    test('sends priority, category and reporter fields', () async {
+      late http.Request captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response('{}', 200);
+      });
+
+      await LinearProxyTransport(
+        endpoint: Uri.parse('https://api.myapp.com/feedback'),
+        httpClient: client,
+      ).send(
+        FeedbackReport(
+          title: 't',
+          description: 'd',
+          screenshotPng: Uint8List.fromList([1]),
+          priority: FeedbackPriority.urgent,
+          category: 'Idea',
+          reporter: const FeedbackReporter(email: 'me@x.com'),
+        ),
+      );
+
+      final body = utf8.decode(captured.bodyBytes, allowMalformed: true);
+      expect(body, contains('name="priority"'));
+      expect(body, contains(FeedbackPriority.urgent.linearValue.toString()));
+      expect(body, contains('Idea'));
+      expect(body, contains('me@x.com'));
+    });
   });
 }

--- a/packages/wise_feedback/test/widgets/linear_feedback_test.dart
+++ b/packages/wise_feedback/test/widgets/linear_feedback_test.dart
@@ -5,14 +5,16 @@ import '../support/fake_transport.dart';
 
 class _FakeCollector implements MetadataCollector {
   @override
-  Future<Map<String, String>> collect() async =>
-      {'platform': 'test', 'appVersion': '9.9'};
+  Future<Map<String, String>> collect() async => {
+    'platform': 'test',
+    'appVersion': '9.9',
+  };
 }
 
 Route<void> _route(String name) => PageRouteBuilder<void>(
-      settings: RouteSettings(name: name),
-      pageBuilder: (_, __, ___) => const SizedBox(),
-    );
+  settings: RouteSettings(name: name),
+  pageBuilder: (_, __, ___) => const SizedBox(),
+);
 
 void main() {
   group('LinearFeedback', () {
@@ -177,8 +179,9 @@ void main() {
       expect(find.text('Bug reported. Thanks!'), findsWidgets);
     });
 
-    testWidgets('attaches metadata, navigation and reporter to the report',
-        (tester) async {
+    testWidgets('attaches metadata, navigation and reporter to the report', (
+      tester,
+    ) async {
       tester.view.physicalSize = const Size(1200, 4000);
       tester.view.devicePixelRatio = 1.0;
       addTearDown(tester.view.reset);

--- a/packages/wise_feedback/test/widgets/linear_feedback_test.dart
+++ b/packages/wise_feedback/test/widgets/linear_feedback_test.dart
@@ -3,6 +3,17 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:wise_feedback/wise_feedback.dart';
 import '../support/fake_transport.dart';
 
+class _FakeCollector implements MetadataCollector {
+  @override
+  Future<Map<String, String>> collect() async =>
+      {'platform': 'test', 'appVersion': '9.9'};
+}
+
+Route<void> _route(String name) => PageRouteBuilder<void>(
+      settings: RouteSettings(name: name),
+      pageBuilder: (_, __, ___) => const SizedBox(),
+    );
+
 void main() {
   group('LinearFeedback', () {
     testWidgets('the built-in button opens the form and submits', (
@@ -164,6 +175,47 @@ void main() {
 
       expect(transport.sent, hasLength(1));
       expect(find.text('Bug reported. Thanks!'), findsWidgets);
+    });
+
+    testWidgets('attaches metadata, navigation and reporter to the report',
+        (tester) async {
+      tester.view.physicalSize = const Size(1200, 4000);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.reset);
+      final transport = FakeTransport();
+      final observer = WiseFeedbackNavigatorObserver()
+        ..didPush(_route('/home'), null)
+        ..didPush(_route('/settings'), null);
+
+      await tester.pumpWidget(
+        LinearFeedback(
+          transport: transport,
+          metadataCollector: _FakeCollector(),
+          navigatorObserver: observer,
+          reporter: () => const FeedbackReporter(email: 'me@x.com'),
+          child: const MaterialApp(home: Scaffold(body: SizedBox.expand())),
+        ),
+      );
+
+      await tester.tap(find.byKey(const Key('wise_feedback_fab')));
+      await tester.pumpAndSettle();
+      await tester.enterText(
+        find.byKey(const Key('wise_feedback_description')),
+        'ctx',
+      );
+      await tester.tap(find.byKey(const Key('wise_feedback_submit')));
+      await tester.runAsync(() async {
+        for (var i = 0; i < 20; i++) {
+          await tester.pump(const Duration(milliseconds: 100));
+          await Future<void>.delayed(const Duration(milliseconds: 20));
+        }
+      });
+
+      final report = transport.sent.single;
+      expect(report.metadata['platform'], 'test');
+      expect(report.metadata['appVersion'], '9.9');
+      expect(report.metadata['navigation'], '/home → /settings');
+      expect(report.reporter?.email, 'me@x.com');
     });
   });
 }


### PR DESCRIPTION
Stacked on #72 . Enriches reports with marker.io-style context — all opt-in and backward-compatible.

### What's new
- **Automatic device/app/OS metadata** via `DeviceMetadataCollector` (`device_info_plus` + `package_info_plus`); opt out with `collectDeviceInfo: false`. Collection never blocks a submit.
- **Navigation breadcrumb** via `WiseFeedbackNavigatorObserver` (add it to your `navigatorObservers` and pass it to `LinearFeedback`).
- **Reporter identity** via a `reporter` builder callback; custom fields via `metadataBuilder`.
- **Priority + category** selectors in the form — priority maps to Linear's native `priority`.
- Both Linear transports render a `## Context` section (reporter, category, priority, environment, recent screens).

Bumps to **0.2.0**.

### Testing
The latest changes can be tested in the **`test/wise-feedback-sandbox`** branch.