### PR TITLE
feat(wise_feedback): configurable issue templates (FeedbackTemplate)

### DIFF
--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.3.0
+
+- Configurable issue templates via `FeedbackTemplate`: the template defines the
+  form's fields and renders the issue body.
+- `DefaultFeedbackTemplate` preserves the previous behavior (single description
+  + context section).
+- `BugReportTemplate`: structured **Current Situation** / **Desired Situation**
+  inputs, **Steps to Reproduce** filled from the navigation breadcrumb, and
+  **Context** (environment, reporter, date & time) filled automatically.
+- `FeedbackReport` now carries `fields` and `createdAt`.
+
 ## 0.2.0
 
 - Automatic device/app/OS metadata attached to every report

--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -8,8 +8,13 @@
   + context section).
 - `BugReportTemplate`: structured **Current Situation** / **Desired Situation**
   inputs, **Steps to Reproduce** filled from the navigation breadcrumb, and
-  **Context** (environment, reporter, date & time) filled automatically.
+  **Context** (environment, reporter, date & time) filled automatically. The
+  timestamp is rendered with `intl`'s `DateFormat`; override the pattern with
+  `BugReportTemplate(datePattern: ...)`.
 - `FeedbackReport` now carries `fields` and `createdAt`.
+- **Breaking:** `FeedbackFormSubmit` takes a single `Map<String, dynamic>` of
+  form values. The old positional description argument was always empty — the
+  body is assembled by the template from `fields`.
 
 ## 0.2.0
 

--- a/packages/wise_feedback/README.md
+++ b/packages/wise_feedback/README.md
@@ -61,6 +61,39 @@ LinearFeedback(
 );
 ```
 
+## Issue templates
+
+The form's fields and the rendered issue body are driven by a
+`FeedbackTemplate`. The default (`DefaultFeedbackTemplate`) is a single
+description plus a context section. Use `BugReportTemplate` for a structured
+bug report, or subclass `FeedbackTemplate` for your own:
+
+```dart
+LinearFeedback(
+  transport: ...,
+  template: const BugReportTemplate(), // Current/Desired + auto Steps/Context
+  navigatorObserver: feedbackObserver, // fills "Steps to Reproduce"
+  reporter: () => FeedbackReporter(email: user.email), // fills "Account or user"
+  metadataBuilder: () => {'environment': env}, // fills "Environment or url"
+  child: MyApp(),
+);
+```
+
+`BugReportTemplate` renders:
+
+```markdown
+## Current Situation
+…
+## Desired Situation
+…
+## Steps to Reproduce
+1. …
+## Context
+Environment or url: …
+Account or user: …
+Date & Time: …
+```
+
 ### Tracking submission progress
 
 The feedback overlay (and its built-in form) is dismissed as soon as a report

--- a/packages/wise_feedback/lib/src/models/feedback_report.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_report.dart
@@ -21,8 +21,9 @@ class FeedbackReport {
 
   /// [metadata] key under which the navigation breadcrumb is stored.
   ///
-  /// Transports read this key to render the trail separately from the rest of
-  /// the environment, so producers and consumers must agree on it.
+  /// The value is a `List<String>` of route names, oldest first. Templates read
+  /// it via `FeedbackTemplate.breadcrumbsOf` and format it themselves, so the
+  /// trail is never flattened to a display string in transit.
   static const String navigationKey = 'navigation';
 
   /// Short summary of the issue.
@@ -52,17 +53,4 @@ class FeedbackReport {
 
   /// When the report was captured.
   final DateTime? createdAt;
-
-  /// Returns a copy with the given fields replaced.
-  FeedbackReport copyWith({String? description}) => FeedbackReport(
-    title: title,
-    description: description ?? this.description,
-    screenshotPng: screenshotPng,
-    metadata: metadata,
-    fields: fields,
-    reporter: reporter,
-    priority: priority,
-    category: category,
-    createdAt: createdAt,
-  );
 }

--- a/packages/wise_feedback/lib/src/models/feedback_report.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_report.dart
@@ -55,14 +55,14 @@ class FeedbackReport {
 
   /// Returns a copy with the given fields replaced.
   FeedbackReport copyWith({String? description}) => FeedbackReport(
-        title: title,
-        description: description ?? this.description,
-        screenshotPng: screenshotPng,
-        metadata: metadata,
-        fields: fields,
-        reporter: reporter,
-        priority: priority,
-        category: category,
-        createdAt: createdAt,
-      );
+    title: title,
+    description: description ?? this.description,
+    screenshotPng: screenshotPng,
+    metadata: metadata,
+    fields: fields,
+    reporter: reporter,
+    priority: priority,
+    category: category,
+    createdAt: createdAt,
+  );
 }

--- a/packages/wise_feedback/lib/src/models/feedback_report.dart
+++ b/packages/wise_feedback/lib/src/models/feedback_report.dart
@@ -12,9 +12,11 @@ class FeedbackReport {
     required this.description,
     required this.screenshotPng,
     this.metadata = const {},
+    this.fields = const {},
     this.reporter,
     this.priority = FeedbackPriority.none,
     this.category,
+    this.createdAt,
   });
 
   /// [metadata] key under which the navigation breadcrumb is stored.
@@ -26,7 +28,8 @@ class FeedbackReport {
   /// Short summary of the issue.
   final String title;
 
-  /// Longer description of the issue.
+  /// The issue body. When a `FeedbackTemplate` is used this holds the rendered
+  /// template output; otherwise it is the raw description text.
   final String description;
 
   /// PNG-encoded screenshot bytes.
@@ -34,6 +37,9 @@ class FeedbackReport {
 
   /// Open extension bag for forward-compatible metadata (device, route, ...).
   final Map<String, Object?> metadata;
+
+  /// Raw values of the form's template fields, keyed by field key.
+  final Map<String, String> fields;
 
   /// Who submitted the report, if known.
   final FeedbackReporter? reporter;
@@ -43,4 +49,20 @@ class FeedbackReport {
 
   /// Optional free-form category (e.g. `Bug`, `Idea`).
   final String? category;
+
+  /// When the report was captured.
+  final DateTime? createdAt;
+
+  /// Returns a copy with the given fields replaced.
+  FeedbackReport copyWith({String? description}) => FeedbackReport(
+        title: title,
+        description: description ?? this.description,
+        screenshotPng: screenshotPng,
+        metadata: metadata,
+        fields: fields,
+        reporter: reporter,
+        priority: priority,
+        category: category,
+        createdAt: createdAt,
+      );
 }

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../models/feedback_priority.dart';
 import '../models/feedback_status.dart';
+import '../template/feedback_field.dart';
 import '../theme/wise_feedback_theme.dart';
 
 /// Wisemen accent used for the submit button.
@@ -13,8 +14,9 @@ const Color _kErrorColor = Color(0xFFD32F2F);
 
 /// Callback invoked when the user submits the form.
 ///
-/// Matches the `feedback` package's submit signature: [description] is the
-/// primary text and [extras] carries the title under key `title`.
+/// The extras map carries `title`, `fields` (a `Map<String, String>` of the
+/// template field values), and — when shown — `priority` (a [FeedbackPriority]
+/// name) and `category`.
 ///
 /// The form reflects the outcome through its `status` listenable rather than
 /// this future's result: on [FeedbackSuccess] the sheet is dismissed, on
@@ -25,23 +27,22 @@ typedef FeedbackFormSubmit =
       Map<String, dynamic>? extras,
     });
 
-/// The built-in title + description form shown over the screenshot.
+/// The built-in feedback form: a title, the template's fields, and optional
+/// priority/category selectors.
 class FeedbackForm extends StatefulWidget {
   /// Creates the form.
   const FeedbackForm({
     required this.onSubmit,
     required this.theme,
     required this.status,
+    required this.fields,
     this.scrollController,
     this.showPriority = false,
     this.categories,
     super.key,
   });
 
-  /// Called with the description and extras on submit.
-  ///
-  /// The extras map carries `title`, and — when the respective field is shown —
-  /// `priority` (a [FeedbackPriority] name) and `category`.
+  /// Called with the field values (in extras) on submit.
   final FeedbackFormSubmit onSubmit;
 
   /// Visual configuration.
@@ -50,11 +51,10 @@ class FeedbackForm extends StatefulWidget {
   /// Submission state used to show progress and disable the button.
   final ValueListenable<FeedbackStatus> status;
 
+  /// The template's editable fields, rendered below the title.
+  final List<FeedbackField> fields;
+
   /// Scroll controller supplied by the surrounding draggable sheet.
-  ///
-  /// Wiring it into the scroll view keeps the sheet's drag-to-resize gesture
-  /// working and lets the content scroll instead of overflowing when the sheet
-  /// is short or the keyboard is open.
   final ScrollController? scrollController;
 
   /// Whether to show a priority selector.
@@ -69,24 +69,33 @@ class FeedbackForm extends StatefulWidget {
 
 class _FeedbackFormState extends State<FeedbackForm> {
   final _titleController = TextEditingController();
-  final _descriptionController = TextEditingController();
+  late final Map<String, TextEditingController> _fieldControllers = {
+    for (final field in widget.fields) field.key: TextEditingController(),
+  };
   FeedbackPriority _priority = FeedbackPriority.none;
   String? _category;
 
   @override
   void dispose() {
     _titleController.dispose();
-    _descriptionController.dispose();
+    for (final controller in _fieldControllers.values) {
+      controller.dispose();
+    }
     super.dispose();
   }
 
   Future<void> _submit() async {
     // The outcome (success dismisses the sheet, failure shows inline below) is
     // reflected through `status`, so nothing here has to change local state.
+    final fieldValues = <String, String>{
+      for (final entry in _fieldControllers.entries)
+        entry.key: entry.value.text,
+    };
     await widget.onSubmit(
-      _descriptionController.text,
+      '',
       extras: <String, dynamic>{
         'title': _titleController.text,
+        'fields': fieldValues,
         if (widget.showPriority) 'priority': _priority.name,
         if (_category != null) 'category': _category,
       },
@@ -124,17 +133,19 @@ class _FeedbackFormState extends State<FeedbackForm> {
                     border: const OutlineInputBorder(),
                   ),
                 ),
-                TextField(
-                  key: const Key('wise_feedback_description'),
-                  controller: _descriptionController,
-                  textCapitalization: TextCapitalization.sentences,
-                  minLines: 2,
-                  maxLines: 4,
-                  decoration: InputDecoration(
-                    labelText: theme.descriptionHint,
-                    border: const OutlineInputBorder(),
+                for (final field in widget.fields)
+                  TextField(
+                    key: Key('wise_feedback_field_${field.key}'),
+                    controller: _fieldControllers[field.key],
+                    textCapitalization: TextCapitalization.sentences,
+                    minLines: field.minLines,
+                    maxLines: field.maxLines,
+                    decoration: InputDecoration(
+                      labelText: field.label,
+                      border: const OutlineInputBorder(),
+                      alignLabelWithHint: true,
+                    ),
                   ),
-                ),
                 if (widget.showPriority)
                   DropdownButtonFormField<FeedbackPriority>(
                     key: const Key('wise_feedback_priority'),

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -14,18 +14,15 @@ const Color _kErrorColor = Color(0xFFD32F2F);
 
 /// Callback invoked when the user submits the form.
 ///
-/// The extras map carries `title`, `fields` (a `Map<String, String>` of the
-/// template field values), and — when shown — `priority` (a [FeedbackPriority]
-/// name) and `category`.
+/// [values] carries `title`, `fields` (a `Map<String, String>` of the template
+/// field values), and — when shown — `priority` (a [FeedbackPriority] name) and
+/// `category`. Every field the form collects travels in here; the body text
+/// itself is assembled later by the feedback template.
 ///
 /// The form reflects the outcome through its `status` listenable rather than
 /// this future's result: on [FeedbackSuccess] the sheet is dismissed, on
 /// [FeedbackFailure] it stays open and shows the error inline.
-typedef FeedbackFormSubmit =
-    Future<void> Function(
-      String description, {
-      Map<String, dynamic>? extras,
-    });
+typedef FeedbackFormSubmit = Future<void> Function(Map<String, dynamic> values);
 
 /// The built-in feedback form: a title, the template's fields, and optional
 /// priority/category selectors.
@@ -91,15 +88,12 @@ class _FeedbackFormState extends State<FeedbackForm> {
       for (final entry in _fieldControllers.entries)
         entry.key: entry.value.text,
     };
-    await widget.onSubmit(
-      '',
-      extras: <String, dynamic>{
-        'title': _titleController.text,
-        'fields': fieldValues,
-        if (widget.showPriority) 'priority': _priority.name,
-        if (_category != null) 'category': _category,
-      },
-    );
+    await widget.onSubmit(<String, dynamic>{
+      'title': _titleController.text,
+      'fields': fieldValues,
+      if (widget.showPriority) 'priority': _priority.name,
+      if (_category != null) 'category': _category,
+    });
   }
 
   @override

--- a/packages/wise_feedback/lib/src/template/bug_report_template.dart
+++ b/packages/wise_feedback/lib/src/template/bug_report_template.dart
@@ -1,0 +1,82 @@
+import '../models/feedback_report.dart';
+import 'feedback_field.dart';
+import 'feedback_template.dart';
+
+/// A structured bug template: **Current Situation** / **Desired Situation**
+/// inputs, with **Steps to Reproduce** filled from the navigation breadcrumb
+/// and **Context** filled automatically (environment, reporter, timestamp).
+class BugReportTemplate extends FeedbackTemplate {
+  /// Creates the template.
+  ///
+  /// [environmentKeys] are the `metadata` keys checked, in order, to fill the
+  /// "Environment or url" line (defaults to `environment`, then `flavor`).
+  const BugReportTemplate({
+    this.currentSituationLabel = 'Current Situation',
+    this.desiredSituationLabel = 'Desired Situation',
+    this.environmentKeys = const ['environment', 'flavor'],
+  });
+
+  /// Label for the current-situation field.
+  final String currentSituationLabel;
+
+  /// Label for the desired-situation field.
+  final String desiredSituationLabel;
+
+  /// Metadata keys checked in order to fill "Environment or url".
+  final List<String> environmentKeys;
+
+  @override
+  List<FeedbackField> get fields => [
+        FeedbackField(key: 'currentSituation', label: currentSituationLabel),
+        FeedbackField(key: 'desiredSituation', label: desiredSituationLabel),
+      ];
+
+  @override
+  String buildBody(FeedbackReport report) {
+    final buffer = StringBuffer()
+      ..writeln('## Current Situation')
+      ..writeln(report.fields['currentSituation'] ?? '')
+      ..writeln()
+      ..writeln('## Desired Situation')
+      ..writeln(report.fields['desiredSituation'] ?? '')
+      ..writeln()
+      ..writeln('## Steps to Reproduce')
+      ..writeln(_steps(report))
+      ..writeln()
+      ..writeln('## Context')
+      ..writeln('Environment or url: ${_environment(report)}')
+      ..writeln('Account or user: ${report.reporter?.email ?? ''}')
+      ..writeln('Date & Time: ${_formatDate(report.createdAt)}');
+    return buffer.toString().trimRight();
+  }
+
+  String _steps(FeedbackReport report) {
+    final navigation = report.metadata['navigation'];
+    if (navigation is! String || navigation.isEmpty) {
+      return '_No navigation recorded._';
+    }
+    final steps = navigation.split(' → ');
+    return [
+      for (var i = 0; i < steps.length; i++) '${i + 1}. ${steps[i]}',
+    ].join('\n');
+  }
+
+  String _environment(FeedbackReport report) {
+    for (final key in environmentKeys) {
+      final value = report.metadata[key];
+      if (value != null) {
+        return value.toString();
+      }
+    }
+    return '';
+  }
+
+  String _formatDate(DateTime? date) {
+    if (date == null) {
+      return '';
+    }
+    String two(int value) => value.toString().padLeft(2, '0');
+    return '${date.year}-${two(date.month)}-${two(date.day)} '
+        '${two(date.hour)}:${two(date.minute)}';
+  }
+}

--- a/packages/wise_feedback/lib/src/template/bug_report_template.dart
+++ b/packages/wise_feedback/lib/src/template/bug_report_template.dart
@@ -27,9 +27,9 @@ class BugReportTemplate extends FeedbackTemplate {
 
   @override
   List<FeedbackField> get fields => [
-        FeedbackField(key: 'currentSituation', label: currentSituationLabel),
-        FeedbackField(key: 'desiredSituation', label: desiredSituationLabel),
-      ];
+    FeedbackField(key: 'currentSituation', label: currentSituationLabel),
+    FeedbackField(key: 'desiredSituation', label: desiredSituationLabel),
+  ];
 
   @override
   String buildBody(FeedbackReport report) {

--- a/packages/wise_feedback/lib/src/template/bug_report_template.dart
+++ b/packages/wise_feedback/lib/src/template/bug_report_template.dart
@@ -1,3 +1,5 @@
+import 'package:intl/intl.dart';
+
 import '../models/feedback_priority.dart';
 import '../models/feedback_reporter.dart';
 import 'feedback_field.dart';
@@ -11,10 +13,14 @@ class BugReportTemplate extends FeedbackTemplate {
   ///
   /// [environmentKeys] are the `metadata` keys checked, in order, to fill the
   /// "Environment or url" line (defaults to `environment`, then `flavor`).
+  ///
+  /// [datePattern] is an `intl` [DateFormat] pattern used for the "Date & Time"
+  /// line.
   const BugReportTemplate({
     this.currentSituationLabel = 'Current Situation',
     this.desiredSituationLabel = 'Desired Situation',
     this.environmentKeys = const ['environment', 'flavor'],
+    this.datePattern = 'yyyy-MM-dd HH:mm',
   });
 
   /// Label for the current-situation field.
@@ -25,6 +31,9 @@ class BugReportTemplate extends FeedbackTemplate {
 
   /// Metadata keys checked in order to fill "Environment or url".
   final List<String> environmentKeys;
+
+  /// [DateFormat] pattern used to render the "Date & Time" line.
+  final String datePattern;
 
   @override
   List<FeedbackField> get fields => [
@@ -82,8 +91,6 @@ class BugReportTemplate extends FeedbackTemplate {
     if (date == null) {
       return '';
     }
-    String two(int value) => value.toString().padLeft(2, '0');
-    return '${date.year}-${two(date.month)}-${two(date.day)} '
-        '${two(date.hour)}:${two(date.minute)}';
+    return DateFormat(datePattern).format(date);
   }
 }

--- a/packages/wise_feedback/lib/src/template/bug_report_template.dart
+++ b/packages/wise_feedback/lib/src/template/bug_report_template.dart
@@ -1,4 +1,5 @@
-import '../models/feedback_report.dart';
+import '../models/feedback_priority.dart';
+import '../models/feedback_reporter.dart';
 import 'feedback_field.dart';
 import 'feedback_template.dart';
 
@@ -32,38 +33,44 @@ class BugReportTemplate extends FeedbackTemplate {
   ];
 
   @override
-  String buildBody(FeedbackReport report) {
+  String buildBody({
+    required Map<String, String> fields,
+    required Map<String, Object?> metadata,
+    FeedbackReporter? reporter,
+    FeedbackPriority priority = FeedbackPriority.none,
+    String? category,
+    DateTime? createdAt,
+  }) {
     final buffer = StringBuffer()
       ..writeln('## Current Situation')
-      ..writeln(report.fields['currentSituation'] ?? '')
+      ..writeln(fields['currentSituation'] ?? '')
       ..writeln()
       ..writeln('## Desired Situation')
-      ..writeln(report.fields['desiredSituation'] ?? '')
+      ..writeln(fields['desiredSituation'] ?? '')
       ..writeln()
       ..writeln('## Steps to Reproduce')
-      ..writeln(_steps(report))
+      ..writeln(_steps(metadata))
       ..writeln()
       ..writeln('## Context')
-      ..writeln('Environment or url: ${_environment(report)}')
-      ..writeln('Account or user: ${report.reporter?.email ?? ''}')
-      ..writeln('Date & Time: ${_formatDate(report.createdAt)}');
+      ..writeln('Environment or url: ${_environment(metadata)}')
+      ..writeln('Account or user: ${reporter?.email ?? ''}')
+      ..writeln('Date & Time: ${_formatDate(createdAt)}');
     return buffer.toString().trimRight();
   }
 
-  String _steps(FeedbackReport report) {
-    final navigation = report.metadata[FeedbackReport.navigationKey];
-    if (navigation is! String || navigation.isEmpty) {
+  String _steps(Map<String, Object?> metadata) {
+    final steps = breadcrumbsOf(metadata);
+    if (steps.isEmpty) {
       return '_No navigation recorded._';
     }
-    final steps = navigation.split(' → ');
     return [
       for (var i = 0; i < steps.length; i++) '${i + 1}. ${steps[i]}',
     ].join('\n');
   }
 
-  String _environment(FeedbackReport report) {
+  String _environment(Map<String, Object?> metadata) {
     for (final key in environmentKeys) {
-      final value = report.metadata[key];
+      final value = metadata[key];
       if (value != null) {
         return value.toString();
       }

--- a/packages/wise_feedback/lib/src/template/bug_report_template.dart
+++ b/packages/wise_feedback/lib/src/template/bug_report_template.dart
@@ -51,7 +51,7 @@ class BugReportTemplate extends FeedbackTemplate {
   }
 
   String _steps(FeedbackReport report) {
-    final navigation = report.metadata['navigation'];
+    final navigation = report.metadata[FeedbackReport.navigationKey];
     if (navigation is! String || navigation.isEmpty) {
       return '_No navigation recorded._';
     }

--- a/packages/wise_feedback/lib/src/template/feedback_field.dart
+++ b/packages/wise_feedback/lib/src/template/feedback_field.dart
@@ -1,0 +1,22 @@
+/// A single editable text field shown in the feedback form.
+class FeedbackField {
+  /// Creates a field. [key] identifies its value in `FeedbackReport.fields`.
+  const FeedbackField({
+    required this.key,
+    required this.label,
+    this.minLines = 2,
+    this.maxLines = 4,
+  });
+
+  /// Stable key used to store and read the value (e.g. `currentSituation`).
+  final String key;
+
+  /// Label shown above the input.
+  final String label;
+
+  /// Minimum visible lines.
+  final int minLines;
+
+  /// Maximum visible lines before scrolling.
+  final int maxLines;
+}

--- a/packages/wise_feedback/lib/src/template/feedback_template.dart
+++ b/packages/wise_feedback/lib/src/template/feedback_template.dart
@@ -1,0 +1,92 @@
+import '../models/feedback_priority.dart';
+import '../models/feedback_report.dart';
+import 'feedback_field.dart';
+
+/// Defines the form inputs and how a [FeedbackReport] renders to an issue body.
+///
+/// Implement this to match your issue tracker's template. The screenshot is
+/// appended by the transport, so [buildBody] should not include it.
+abstract class FeedbackTemplate {
+  /// Const base constructor so templates can be declared `const`.
+  const FeedbackTemplate();
+
+  /// The editable text fields shown in the form (below the title).
+  List<FeedbackField> get fields;
+
+  /// Renders the issue body (markdown) from a completed [report].
+  String buildBody(FeedbackReport report);
+}
+
+/// The default template: a single description field plus a `## Context`
+/// section listing reporter, category, priority, environment and recent
+/// screens. Preserves the package's original issue format.
+class DefaultFeedbackTemplate extends FeedbackTemplate {
+  /// Creates the default template.
+  const DefaultFeedbackTemplate({this.descriptionLabel = 'Description'});
+
+  /// Label for the single description field.
+  final String descriptionLabel;
+
+  @override
+  List<FeedbackField> get fields => [
+        FeedbackField(key: 'description', label: descriptionLabel),
+      ];
+
+  @override
+  String buildBody(FeedbackReport report) {
+    final buffer = StringBuffer(report.fields['description'] ?? '');
+    final context = <String>[];
+
+    final who = formatReporter(report);
+    if (who != null) {
+      context.add('**Reported by:** $who');
+    }
+    if (report.category case final String category) {
+      context.add('**Category:** $category');
+    }
+    if (report.priority != FeedbackPriority.none) {
+      context.add('**Priority:** ${report.priority.label}');
+    }
+
+    final environment = renderEnvironmentBullets(report);
+    final navigation = report.metadata['navigation'];
+
+    if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
+      buffer.write('\n\n## Context\n');
+      if (context.isNotEmpty) {
+        buffer.write('${context.join('\n')}\n');
+      }
+      if (environment.isNotEmpty) {
+        buffer.write('\n**Environment**\n${environment.join('\n')}\n');
+      }
+      if (navigation != null) {
+        buffer.write('\n**Recent screens:** $navigation\n');
+      }
+    }
+    return buffer.toString().trimRight();
+  }
+}
+
+/// Formats the reporter as `name · email` (or the id), or null when unknown.
+String? formatReporter(FeedbackReport report) {
+  final reporter = report.reporter;
+  if (reporter == null || reporter.isEmpty) {
+    return null;
+  }
+  final named = <String?>[reporter.name, reporter.email]
+      .whereType<String>()
+      .where((value) => value.isNotEmpty)
+      .toList();
+  if (named.isNotEmpty) {
+    return named.join(' · ');
+  }
+  return reporter.id;
+}
+
+/// Renders `report.metadata` (excluding the `navigation` key) as markdown
+/// bullet lines.
+List<String> renderEnvironmentBullets(FeedbackReport report) =>
+    report.metadata.entries
+        .where((entry) => entry.key != 'navigation')
+        .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
+        .toList();

--- a/packages/wise_feedback/lib/src/template/feedback_template.dart
+++ b/packages/wise_feedback/lib/src/template/feedback_template.dart
@@ -29,8 +29,8 @@ class DefaultFeedbackTemplate extends FeedbackTemplate {
 
   @override
   List<FeedbackField> get fields => [
-        FeedbackField(key: 'description', label: descriptionLabel),
-      ];
+    FeedbackField(key: 'description', label: descriptionLabel),
+  ];
 
   @override
   String buildBody(FeedbackReport report) {
@@ -73,10 +73,10 @@ String? formatReporter(FeedbackReport report) {
   if (reporter == null || reporter.isEmpty) {
     return null;
   }
-  final named = <String?>[reporter.name, reporter.email]
-      .whereType<String>()
-      .where((value) => value.isNotEmpty)
-      .toList();
+  final named = <String?>[
+    reporter.name,
+    reporter.email,
+  ].whereType<String>().where((value) => value.isNotEmpty).toList();
   if (named.isNotEmpty) {
     return named.join(' · ');
   }
@@ -85,8 +85,9 @@ String? formatReporter(FeedbackReport report) {
 
 /// Renders `report.metadata` (excluding the `navigation` key) as markdown
 /// bullet lines.
-List<String> renderEnvironmentBullets(FeedbackReport report) =>
-    report.metadata.entries
-        .where((entry) => entry.key != 'navigation')
-        .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
-        .toList();
+List<String> renderEnvironmentBullets(FeedbackReport report) => report
+    .metadata
+    .entries
+    .where((entry) => entry.key != 'navigation')
+    .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
+    .toList();

--- a/packages/wise_feedback/lib/src/template/feedback_template.dart
+++ b/packages/wise_feedback/lib/src/template/feedback_template.dart
@@ -49,7 +49,7 @@ class DefaultFeedbackTemplate extends FeedbackTemplate {
     }
 
     final environment = renderEnvironmentBullets(report);
-    final navigation = report.metadata['navigation'];
+    final navigation = report.metadata[FeedbackReport.navigationKey];
 
     if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
       buffer.write('\n\n## Context\n');
@@ -88,6 +88,6 @@ String? formatReporter(FeedbackReport report) {
 List<String> renderEnvironmentBullets(FeedbackReport report) => report
     .metadata
     .entries
-    .where((entry) => entry.key != 'navigation')
+    .where((entry) => entry.key != FeedbackReport.navigationKey)
     .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
     .toList();

--- a/packages/wise_feedback/lib/src/template/feedback_template.dart
+++ b/packages/wise_feedback/lib/src/template/feedback_template.dart
@@ -1,8 +1,9 @@
 import '../models/feedback_priority.dart';
 import '../models/feedback_report.dart';
+import '../models/feedback_reporter.dart';
 import 'feedback_field.dart';
 
-/// Defines the form inputs and how a [FeedbackReport] renders to an issue body.
+/// Defines the form inputs and how a completed report renders to an issue body.
 ///
 /// Implement this to match your issue tracker's template. The screenshot is
 /// appended by the transport, so [buildBody] should not include it.
@@ -13,8 +14,55 @@ abstract class FeedbackTemplate {
   /// The editable text fields shown in the form (below the title).
   List<FeedbackField> get fields;
 
-  /// Renders the issue body (markdown) from a completed [report].
-  String buildBody(FeedbackReport report);
+  /// Renders the issue body (markdown) from the captured values.
+  ///
+  /// Takes the report's parts rather than a [FeedbackReport], because the body
+  /// this returns *becomes* that report's description — there is no complete
+  /// report to hand over yet.
+  String buildBody({
+    required Map<String, String> fields,
+    required Map<String, Object?> metadata,
+    FeedbackReporter? reporter,
+    FeedbackPriority priority = FeedbackPriority.none,
+    String? category,
+    DateTime? createdAt,
+  });
+
+  /// Formats [reporter] as `name · email` (or the id), or null when unknown.
+  ///
+  /// Available to subclasses building a context section.
+  String? formatReporter(FeedbackReporter? reporter) {
+    if (reporter == null || reporter.isEmpty) {
+      return null;
+    }
+    final named = <String?>[
+      reporter.name,
+      reporter.email,
+    ].whereType<String>().where((value) => value.isNotEmpty).toList();
+    if (named.isNotEmpty) {
+      return named.join(' · ');
+    }
+    return reporter.id;
+  }
+
+  /// Renders [metadata] as markdown bullet lines, excluding the navigation
+  /// breadcrumb, which templates present separately.
+  ///
+  /// Available to subclasses building a context section.
+  List<String> renderEnvironmentBullets(Map<String, Object?> metadata) =>
+      metadata.entries
+          .where((entry) => entry.key != FeedbackReport.navigationKey)
+          .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
+          .toList();
+
+  /// Reads the navigation breadcrumb from [metadata], oldest screen first.
+  ///
+  /// Empty when no trail was recorded.
+  List<String> breadcrumbsOf(Map<String, Object?> metadata) =>
+      switch (metadata[FeedbackReport.navigationKey]) {
+        final List<String> trail => trail,
+        _ => const <String>[],
+      };
 }
 
 /// The default template: a single description field plus a `## Context`
@@ -33,25 +81,34 @@ class DefaultFeedbackTemplate extends FeedbackTemplate {
   ];
 
   @override
-  String buildBody(FeedbackReport report) {
-    final buffer = StringBuffer(report.fields['description'] ?? '');
+  String buildBody({
+    required Map<String, String> fields,
+    required Map<String, Object?> metadata,
+    FeedbackReporter? reporter,
+    FeedbackPriority priority = FeedbackPriority.none,
+    String? category,
+    DateTime? createdAt,
+  }) {
+    final buffer = StringBuffer(fields['description'] ?? '');
     final context = <String>[];
 
-    final who = formatReporter(report);
+    final who = formatReporter(reporter);
     if (who != null) {
       context.add('**Reported by:** $who');
     }
-    if (report.category case final String category) {
-      context.add('**Category:** $category');
+    if (category case final String value) {
+      context.add('**Category:** $value');
     }
-    if (report.priority != FeedbackPriority.none) {
-      context.add('**Priority:** ${report.priority.label}');
+    if (priority != FeedbackPriority.none) {
+      context.add('**Priority:** ${priority.label}');
     }
 
-    final environment = renderEnvironmentBullets(report);
-    final navigation = report.metadata[FeedbackReport.navigationKey];
+    final environment = renderEnvironmentBullets(metadata);
+    final breadcrumbs = breadcrumbsOf(metadata);
 
-    if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
+    if (context.isNotEmpty ||
+        environment.isNotEmpty ||
+        breadcrumbs.isNotEmpty) {
       buffer.write('\n\n## Context\n');
       if (context.isNotEmpty) {
         buffer.write('${context.join('\n')}\n');
@@ -59,35 +116,10 @@ class DefaultFeedbackTemplate extends FeedbackTemplate {
       if (environment.isNotEmpty) {
         buffer.write('\n**Environment**\n${environment.join('\n')}\n');
       }
-      if (navigation != null) {
-        buffer.write('\n**Recent screens:** $navigation\n');
+      if (breadcrumbs.isNotEmpty) {
+        buffer.write('\n**Recent screens:** ${breadcrumbs.join(' → ')}\n');
       }
     }
     return buffer.toString().trimRight();
   }
 }
-
-/// Formats the reporter as `name · email` (or the id), or null when unknown.
-String? formatReporter(FeedbackReport report) {
-  final reporter = report.reporter;
-  if (reporter == null || reporter.isEmpty) {
-    return null;
-  }
-  final named = <String?>[
-    reporter.name,
-    reporter.email,
-  ].whereType<String>().where((value) => value.isNotEmpty).toList();
-  if (named.isNotEmpty) {
-    return named.join(' · ');
-  }
-  return reporter.id;
-}
-
-/// Renders `report.metadata` (excluding the `navigation` key) as markdown
-/// bullet lines.
-List<String> renderEnvironmentBullets(FeedbackReport report) => report
-    .metadata
-    .entries
-    .where((entry) => entry.key != FeedbackReport.navigationKey)
-    .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
-    .toList();

--- a/packages/wise_feedback/lib/src/template/template.dart
+++ b/packages/wise_feedback/lib/src/template/template.dart
@@ -1,0 +1,3 @@
+export 'bug_report_template.dart';
+export 'feedback_field.dart';
+export 'feedback_template.dart';

--- a/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
+++ b/packages/wise_feedback/lib/src/transport/linear_direct_transport.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/feedback_exception.dart';
-import '../models/feedback_priority.dart';
 import '../models/feedback_report.dart';
 import '../models/feedback_result.dart';
 import 'feedback_transport.dart';
@@ -134,52 +133,9 @@ mutation IssueCreate($title: String!, $description: String!, $teamId: String!, $
     );
   }
 
-  /// Builds the issue body: the user's text, a `## Context` section rendering
-  /// reporter/category/priority/environment/navigation, then the screenshot.
-  String _renderBody(FeedbackReport report, String assetUrl) {
-    final buffer = StringBuffer(report.description);
-    final context = <String>[];
-
-    final reporter = report.reporter;
-    if (reporter != null && !reporter.isEmpty) {
-      final named = <String?>[
-        reporter.name,
-        reporter.email,
-      ].whereType<String>().where((value) => value.isNotEmpty).toList();
-      final who = named.isNotEmpty ? named.join(' · ') : (reporter.id ?? '');
-      if (who.isNotEmpty) {
-        context.add('**Reported by:** $who');
-      }
-    }
-    if (report.category case final String category) {
-      context.add('**Category:** $category');
-    }
-    if (report.priority != FeedbackPriority.none) {
-      context.add('**Priority:** ${report.priority.label}');
-    }
-
-    final environment = report.metadata.entries
-        .where((entry) => entry.key != FeedbackReport.navigationKey)
-        .map((entry) => '- **${entry.key}:** ${entry.value ?? ''}')
-        .toList();
-    final navigation = report.metadata[FeedbackReport.navigationKey];
-
-    if (context.isNotEmpty || environment.isNotEmpty || navigation != null) {
-      buffer.write('\n\n## Context\n');
-      if (context.isNotEmpty) {
-        buffer.write('${context.join('\n')}\n');
-      }
-      if (environment.isNotEmpty) {
-        buffer.write('\n**Environment**\n${environment.join('\n')}\n');
-      }
-      if (navigation != null) {
-        buffer.write('\n**Recent screens:** $navigation\n');
-      }
-    }
-
-    buffer.write('\n\n![screenshot]($assetUrl)');
-    return buffer.toString();
-  }
+  /// Appends the uploaded screenshot to the template-rendered body.
+  String _renderBody(FeedbackReport report, String assetUrl) =>
+      '${report.description}\n\n![screenshot]($assetUrl)';
 
   Future<Json> _graphql(
     String query,

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -12,6 +12,7 @@ import '../models/feedback_report.dart';
 import '../models/feedback_reporter.dart';
 import '../models/feedback_status.dart';
 import '../screens/feedback_form.dart';
+import '../template/feedback_template.dart';
 import '../theme/wise_feedback_theme.dart';
 import '../transport/feedback_transport.dart';
 import 'feedback_button.dart';
@@ -44,6 +45,7 @@ class LinearFeedback extends StatefulWidget {
     this.metadataBuilder,
     this.showPriority = true,
     this.categories,
+    this.template = const DefaultFeedbackTemplate(),
     super.key,
   });
 
@@ -90,6 +92,12 @@ class LinearFeedback extends StatefulWidget {
 
   /// Category options to offer in the form, or null to hide the selector.
   final List<String>? categories;
+
+  /// Defines the form's fields and how the issue body is rendered.
+  ///
+  /// Defaults to [DefaultFeedbackTemplate]. Use `BugReportTemplate` or a custom
+  /// [FeedbackTemplate] for a structured layout.
+  final FeedbackTemplate template;
 
   @override
   State<LinearFeedback> createState() => _LinearFeedbackState();
@@ -150,16 +158,23 @@ class _LinearFeedbackState extends State<LinearFeedback> {
     final extra = feedback.extra ?? const <String, dynamic>{};
     final metadata = await _collectMetadata();
     final reporter = await _resolveReporter();
+    final fields = (extra['fields'] as Map?)?.map(
+          (key, value) => MapEntry(key.toString(), value.toString()),
+        ) ??
+        const <String, String>{};
+    final report = FeedbackReport(
+      title: (extra['title'] as String?) ?? '',
+      description: '',
+      screenshotPng: feedback.screenshot,
+      metadata: metadata,
+      fields: fields,
+      reporter: reporter,
+      priority: _priorityFromName(extra['priority'] as String?),
+      category: extra['category'] as String?,
+      createdAt: DateTime.now(),
+    );
     await _controller.submit(
-      FeedbackReport(
-        title: (extra['title'] as String?) ?? '',
-        description: feedback.text,
-        screenshotPng: feedback.screenshot,
-        metadata: metadata,
-        reporter: reporter,
-        priority: _priorityFromName(extra['priority'] as String?),
-        category: extra['category'] as String?,
-      ),
+      report.copyWith(description: widget.template.buildBody(report)),
     );
     final status = _controller.value;
     if (status is FeedbackFailure) {
@@ -252,6 +267,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         theme: widget.theme,
         status: _controller,
         scrollController: scrollController,
+        fields: widget.template.fields,
         showPriority: widget.showPriority,
         categories: widget.categories,
         onSubmit: (description, {extras}) =>

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -163,19 +163,28 @@ class _LinearFeedbackState extends State<LinearFeedback> {
           (key, value) => MapEntry(key.toString(), value.toString()),
         ) ??
         const <String, String>{};
-    final report = FeedbackReport(
-      title: (extra['title'] as String?) ?? '',
-      description: '',
-      screenshotPng: feedback.screenshot,
-      metadata: metadata,
-      fields: fields,
-      reporter: reporter,
-      priority: _priorityFromName(extra['priority'] as String?),
-      category: extra['category'] as String?,
-      createdAt: DateTime.now(),
-    );
+    final priority = _priorityFromName(extra['priority'] as String?);
+    final category = extra['category'] as String?;
+    final createdAt = DateTime.now();
     await _controller.submit(
-      report.copyWith(description: widget.template.buildBody(report)),
+      FeedbackReport(
+        title: (extra['title'] as String?) ?? '',
+        description: widget.template.buildBody(
+          fields: fields,
+          metadata: metadata,
+          reporter: reporter,
+          priority: priority,
+          category: category,
+          createdAt: createdAt,
+        ),
+        screenshotPng: feedback.screenshot,
+        metadata: metadata,
+        fields: fields,
+        reporter: reporter,
+        priority: priority,
+        category: category,
+        createdAt: createdAt,
+      ),
     );
     final status = _controller.value;
     if (status is FeedbackFailure) {
@@ -216,7 +225,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
 
     final observer = widget.navigatorObserver;
     if (observer != null && observer.breadcrumbs.isNotEmpty) {
-      metadata[FeedbackReport.navigationKey] = observer.breadcrumbs.join(' → ');
+      metadata[FeedbackReport.navigationKey] = observer.breadcrumbs;
     }
 
     return metadata;

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -158,7 +158,8 @@ class _LinearFeedbackState extends State<LinearFeedback> {
     final extra = feedback.extra ?? const <String, dynamic>{};
     final metadata = await _collectMetadata();
     final reporter = await _resolveReporter();
-    final fields = (extra['fields'] as Map?)?.map(
+    final fields =
+        (extra['fields'] as Map?)?.map(
           (key, value) => MapEntry(key.toString(), value.toString()),
         ) ??
         const <String, String>{};

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -251,11 +251,13 @@ class _LinearFeedbackState extends State<LinearFeedback> {
 
   Future<void> _submit(
     OnSubmit packageOnSubmit,
-    String description,
-    Map<String, dynamic>? extras,
+    Map<String, dynamic> values,
   ) async {
     try {
-      await packageOnSubmit(description, extras: extras);
+      // The feedback package's own signature wants a text payload, but all of
+      // our content travels in `extras` and is read back off `UserFeedback.extra`
+      // in _handleUserFeedback, so the text is deliberately empty.
+      await packageOnSubmit('', extras: values);
       _toasts.show(
         _overlayContext,
         widget.theme.successMessage,
@@ -280,8 +282,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         fields: widget.template.fields,
         showPriority: widget.showPriority,
         categories: widget.categories,
-        onSubmit: (description, {extras}) =>
-            _submit(onSubmit, description, extras),
+        onSubmit: (values) => _submit(onSubmit, values),
       ),
       child: Builder(
         builder: (betterFeedbackContext) {

--- a/packages/wise_feedback/lib/wise_feedback.dart
+++ b/packages/wise_feedback/lib/wise_feedback.dart
@@ -4,6 +4,7 @@ library wise_feedback;
 export 'src/metadata/metadata.dart';
 export 'src/models/models.dart';
 export 'src/screens/screens.dart';
+export 'src/template/template.dart';
 export 'src/theme/theme.dart';
 export 'src/transport/transport.dart';
 export 'src/widgets/widgets.dart';

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wise_feedback
 description: In-app bug reporting for Flutter that files a screenshot, title and description as a Linear issue, via a pluggable transport (direct token or backend proxy).
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 repository: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   auto_route: ">=11.0.0 <12.0.0"
   # Screenshot capture + feedback overlay
   feedback: ">=3.2.0 <4.0.0"
+  # Date formatting in issue templates
+  intl: ">=0.20.2 <1.0.0"
   # Transport HTTP + GraphQL-over-HTTP
   http: ">=1.2.0 <2.0.0"
   # Automatic report metadata

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -2,12 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wise_feedback/wise_feedback.dart';
 
+const _fields = [FeedbackField(key: 'description', label: 'Description')];
+
 void main() {
   group('FeedbackForm', () {
-    testWidgets('submitting the form forwards title and description', (
+    testWidgets('submitting forwards the title and field values', (
       tester,
     ) async {
-      String? gotDescription;
       Map<String, dynamic>? gotExtras;
       final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
 
@@ -17,8 +18,8 @@ void main() {
             body: FeedbackForm(
               theme: const WiseFeedbackTheme(),
               status: status,
+              fields: _fields,
               onSubmit: (description, {extras}) async {
-                gotDescription = description;
                 gotExtras = extras;
               },
             ),
@@ -31,14 +32,15 @@ void main() {
         'My title',
       );
       await tester.enterText(
-        find.byKey(const Key('wise_feedback_description')),
+        find.byKey(const Key('wise_feedback_field_description')),
         'My description',
       );
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
       await tester.pump();
 
-      expect(gotDescription, 'My description');
       expect(gotExtras?['title'], 'My title');
+      final fields = gotExtras?['fields'] as Map<String, String>;
+      expect(fields['description'], 'My description');
     });
 
     testWidgets('shows a progress indicator while submitting', (tester) async {
@@ -49,6 +51,7 @@ void main() {
             body: FeedbackForm(
               theme: const WiseFeedbackTheme(),
               status: status,
+              fields: _fields,
               onSubmit: (description, {extras}) async {},
             ),
           ),
@@ -67,6 +70,7 @@ void main() {
             body: FeedbackForm(
               theme: const WiseFeedbackTheme(),
               status: status,
+              fields: _fields,
               onSubmit: (description, {extras}) async {},
             ),
           ),
@@ -85,6 +89,33 @@ void main() {
       expect(find.byKey(const Key('wise_feedback_submit')), findsOneWidget);
     });
 
+    testWidgets('renders a field per template field', (tester) async {
+      final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackForm(
+              theme: const WiseFeedbackTheme(),
+              status: status,
+              fields: const [
+                FeedbackField(key: 'currentSituation', label: 'Current'),
+                FeedbackField(key: 'desiredSituation', label: 'Desired'),
+              ],
+              onSubmit: (description, {extras}) async {},
+            ),
+          ),
+        ),
+      );
+      expect(
+        find.byKey(const Key('wise_feedback_field_currentSituation')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('wise_feedback_field_desiredSituation')),
+        findsOneWidget,
+      );
+    });
+
     testWidgets('forwards selected priority and category in extras', (
       tester,
     ) async {
@@ -97,6 +128,7 @@ void main() {
             body: FeedbackForm(
               theme: const WiseFeedbackTheme(),
               status: status,
+              fields: _fields,
               showPriority: true,
               categories: const ['Bug', 'Idea'],
               onSubmit: (description, {extras}) async {
@@ -132,6 +164,7 @@ void main() {
             body: FeedbackForm(
               theme: const WiseFeedbackTheme(),
               status: status,
+              fields: _fields,
               onSubmit: (description, {extras}) async {},
             ),
           ),
@@ -157,6 +190,7 @@ void main() {
                 child: FeedbackForm(
                   theme: const WiseFeedbackTheme(),
                   status: status,
+                  fields: _fields,
                   onSubmit: (description, {extras}) async {},
                 ),
               ),

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -9,7 +9,7 @@ void main() {
     testWidgets('submitting forwards the title and field values', (
       tester,
     ) async {
-      Map<String, dynamic>? gotExtras;
+      Map<String, dynamic>? gotValues;
       final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
 
       await tester.pumpWidget(
@@ -19,8 +19,8 @@ void main() {
               theme: const WiseFeedbackTheme(),
               status: status,
               fields: _fields,
-              onSubmit: (description, {extras}) async {
-                gotExtras = extras;
+              onSubmit: (values) async {
+                gotValues = values;
               },
             ),
           ),
@@ -38,8 +38,8 @@ void main() {
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
       await tester.pump();
 
-      expect(gotExtras?['title'], 'My title');
-      final fields = gotExtras?['fields'] as Map<String, String>;
+      expect(gotValues?['title'], 'My title');
+      final fields = gotValues?['fields'] as Map<String, String>;
       expect(fields['description'], 'My description');
     });
 
@@ -52,7 +52,7 @@ void main() {
               theme: const WiseFeedbackTheme(),
               status: status,
               fields: _fields,
-              onSubmit: (description, {extras}) async {},
+              onSubmit: (values) async {},
             ),
           ),
         ),
@@ -71,7 +71,7 @@ void main() {
               theme: const WiseFeedbackTheme(),
               status: status,
               fields: _fields,
-              onSubmit: (description, {extras}) async {},
+              onSubmit: (values) async {},
             ),
           ),
         ),
@@ -101,7 +101,7 @@ void main() {
                 FeedbackField(key: 'currentSituation', label: 'Current'),
                 FeedbackField(key: 'desiredSituation', label: 'Desired'),
               ],
-              onSubmit: (description, {extras}) async {},
+              onSubmit: (values) async {},
             ),
           ),
         ),
@@ -119,7 +119,7 @@ void main() {
     testWidgets('forwards selected priority and category in extras', (
       tester,
     ) async {
-      Map<String, dynamic>? gotExtras;
+      Map<String, dynamic>? gotValues;
       final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
 
       await tester.pumpWidget(
@@ -131,8 +131,8 @@ void main() {
               fields: _fields,
               showPriority: true,
               categories: const ['Bug', 'Idea'],
-              onSubmit: (description, {extras}) async {
-                gotExtras = extras;
+              onSubmit: (values) async {
+                gotValues = values;
               },
             ),
           ),
@@ -152,8 +152,8 @@ void main() {
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
       await tester.pump();
 
-      expect(gotExtras?['priority'], 'high');
-      expect(gotExtras?['category'], 'Idea');
+      expect(gotValues?['priority'], 'high');
+      expect(gotValues?['category'], 'Idea');
     });
 
     testWidgets('hides priority and category by default', (tester) async {
@@ -165,7 +165,7 @@ void main() {
               theme: const WiseFeedbackTheme(),
               status: status,
               fields: _fields,
-              onSubmit: (description, {extras}) async {},
+              onSubmit: (values) async {},
             ),
           ),
         ),
@@ -191,7 +191,7 @@ void main() {
                   theme: const WiseFeedbackTheme(),
                   status: status,
                   fields: _fields,
-                  onSubmit: (description, {extras}) async {},
+                  onSubmit: (values) async {},
                 ),
               ),
             ),

--- a/packages/wise_feedback/test/template/feedback_template_test.dart
+++ b/packages/wise_feedback/test/template/feedback_template_test.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wise_feedback/wise_feedback.dart';
+
+FeedbackReport _report({
+  Map<String, String> fields = const {},
+  Map<String, Object?> metadata = const {},
+  FeedbackReporter? reporter,
+  FeedbackPriority priority = FeedbackPriority.none,
+  String? category,
+  DateTime? createdAt,
+}) =>
+    FeedbackReport(
+      title: 't',
+      description: '',
+      screenshotPng: Uint8List(0),
+      fields: fields,
+      metadata: metadata,
+      reporter: reporter,
+      priority: priority,
+      category: category,
+      createdAt: createdAt,
+    );
+
+void main() {
+  group('DefaultFeedbackTemplate', () {
+    const template = DefaultFeedbackTemplate();
+
+    test('exposes a single description field', () {
+      expect(template.fields, hasLength(1));
+      expect(template.fields.single.key, 'description');
+    });
+
+    test('renders description plus a context section', () {
+      final body = template.buildBody(
+        _report(
+          fields: const {'description': 'It broke'},
+          reporter: const FeedbackReporter(email: 'a@b.c'),
+          category: 'Bug',
+          priority: FeedbackPriority.high,
+          metadata: const {'appVersion': '1.2.3', 'navigation': '/a → /b'},
+        ),
+      );
+      expect(body, startsWith('It broke'));
+      expect(body, contains('## Context'));
+      expect(body, contains('**Reported by:** a@b.c'));
+      expect(body, contains('**Category:** Bug'));
+      expect(body, contains('**Priority:** High'));
+      expect(body, contains('appVersion'));
+      expect(body, contains('**Recent screens:** /a → /b'));
+    });
+  });
+
+  group('BugReportTemplate', () {
+    const template = BugReportTemplate();
+
+    test('exposes current and desired situation fields', () {
+      expect(
+        template.fields.map((f) => f.key),
+        ['currentSituation', 'desiredSituation'],
+      );
+    });
+
+    test('renders the bug template sections', () {
+      final body = template.buildBody(
+        _report(
+          fields: const {
+            'currentSituation': 'I get an error',
+            'desiredSituation': 'It works',
+          },
+          reporter: const FeedbackReporter(email: 'john.doe@wisemen.digital'),
+          metadata: const {
+            'environment': 'staging',
+            'navigation': 'Overview → Detail → Delete',
+          },
+          createdAt: DateTime(2025, 9, 9, 14),
+        ),
+      );
+
+      expect(body, contains('## Current Situation\nI get an error'));
+      expect(body, contains('## Desired Situation\nIt works'));
+      expect(body, contains('## Steps to Reproduce'));
+      expect(body, contains('1. Overview'));
+      expect(body, contains('2. Detail'));
+      expect(body, contains('3. Delete'));
+      expect(body, contains('Environment or url: staging'));
+      expect(body, contains('Account or user: john.doe@wisemen.digital'));
+      expect(body, contains('Date & Time: 2025-09-09 14:00'));
+    });
+
+    test('falls back gracefully when navigation is absent', () {
+      final body = template.buildBody(_report());
+      expect(body, contains('_No navigation recorded._'));
+    });
+  });
+}

--- a/packages/wise_feedback/test/template/feedback_template_test.dart
+++ b/packages/wise_feedback/test/template/feedback_template_test.dart
@@ -1,25 +1,5 @@
-import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:wise_feedback/wise_feedback.dart';
-
-FeedbackReport _report({
-  Map<String, String> fields = const {},
-  Map<String, Object?> metadata = const {},
-  FeedbackReporter? reporter,
-  FeedbackPriority priority = FeedbackPriority.none,
-  String? category,
-  DateTime? createdAt,
-}) => FeedbackReport(
-  title: 't',
-  description: '',
-  screenshotPng: Uint8List(0),
-  fields: fields,
-  metadata: metadata,
-  reporter: reporter,
-  priority: priority,
-  category: category,
-  createdAt: createdAt,
-);
 
 void main() {
   group('DefaultFeedbackTemplate', () {
@@ -32,13 +12,14 @@ void main() {
 
     test('renders description plus a context section', () {
       final body = template.buildBody(
-        _report(
-          fields: const {'description': 'It broke'},
-          reporter: const FeedbackReporter(email: 'a@b.c'),
-          category: 'Bug',
-          priority: FeedbackPriority.high,
-          metadata: const {'appVersion': '1.2.3', 'navigation': '/a → /b'},
-        ),
+        fields: const {'description': 'It broke'},
+        metadata: const {
+          'appVersion': '1.2.3',
+          FeedbackReport.navigationKey: ['/a', '/b'],
+        },
+        reporter: const FeedbackReporter(email: 'a@b.c'),
+        category: 'Bug',
+        priority: FeedbackPriority.high,
       );
       expect(body, startsWith('It broke'));
       expect(body, contains('## Context'));
@@ -48,32 +29,38 @@ void main() {
       expect(body, contains('appVersion'));
       expect(body, contains('**Recent screens:** /a → /b'));
     });
+
+    test('omits the breadcrumb line when no trail was recorded', () {
+      final body = template.buildBody(
+        fields: const {'description': 'It broke'},
+        metadata: const {'appVersion': '1.2.3'},
+      );
+      expect(body, isNot(contains('Recent screens')));
+    });
   });
 
   group('BugReportTemplate', () {
     const template = BugReportTemplate();
 
     test('exposes current and desired situation fields', () {
-      expect(
-        template.fields.map((f) => f.key),
-        ['currentSituation', 'desiredSituation'],
-      );
+      expect(template.fields.map((f) => f.key), [
+        'currentSituation',
+        'desiredSituation',
+      ]);
     });
 
     test('renders the bug template sections', () {
       final body = template.buildBody(
-        _report(
-          fields: const {
-            'currentSituation': 'I get an error',
-            'desiredSituation': 'It works',
-          },
-          reporter: const FeedbackReporter(email: 'john.doe@wisemen.digital'),
-          metadata: const {
-            'environment': 'staging',
-            'navigation': 'Overview → Detail → Delete',
-          },
-          createdAt: DateTime(2025, 9, 9, 14),
-        ),
+        fields: const {
+          'currentSituation': 'I get an error',
+          'desiredSituation': 'It works',
+        },
+        metadata: const {
+          'environment': 'staging',
+          FeedbackReport.navigationKey: ['Overview', 'Detail', 'Delete'],
+        },
+        reporter: const FeedbackReporter(email: 'john.doe@wisemen.digital'),
+        createdAt: DateTime(2025, 9, 9, 14),
       );
 
       expect(body, contains('## Current Situation\nI get an error'));
@@ -88,8 +75,20 @@ void main() {
     });
 
     test('falls back gracefully when navigation is absent', () {
-      final body = template.buildBody(_report());
+      final body = template.buildBody(fields: const {}, metadata: const {});
       expect(body, contains('_No navigation recorded._'));
+    });
+
+    test('keeps a route name containing the separator as one step', () {
+      final body = template.buildBody(
+        fields: const {},
+        metadata: const {
+          FeedbackReport.navigationKey: ['Overview → Detail', 'Delete'],
+        },
+      );
+      expect(body, contains('1. Overview → Detail'));
+      expect(body, contains('2. Delete'));
+      expect(body, isNot(contains('3.')));
     });
   });
 }

--- a/packages/wise_feedback/test/template/feedback_template_test.dart
+++ b/packages/wise_feedback/test/template/feedback_template_test.dart
@@ -74,6 +74,22 @@ void main() {
       expect(body, contains('Date & Time: 2025-09-09 14:00'));
     });
 
+    test('renders the timestamp with a custom date pattern', () {
+      const custom = BugReportTemplate(datePattern: 'dd/MM/yyyy HH:mm:ss');
+      final body = custom.buildBody(
+        fields: const {},
+        metadata: const {},
+        createdAt: DateTime(2025, 9, 9, 14, 5, 30),
+      );
+      expect(body, contains('Date & Time: 09/09/2025 14:05:30'));
+    });
+
+    test('leaves the timestamp empty when createdAt is absent', () {
+      final body = template.buildBody(fields: const {}, metadata: const {});
+      // buildBody trims the trailing whitespace off the empty value.
+      expect(body, endsWith('Date & Time:'));
+    });
+
     test('falls back gracefully when navigation is absent', () {
       final body = template.buildBody(fields: const {}, metadata: const {});
       expect(body, contains('_No navigation recorded._'));

--- a/packages/wise_feedback/test/template/feedback_template_test.dart
+++ b/packages/wise_feedback/test/template/feedback_template_test.dart
@@ -9,18 +9,17 @@ FeedbackReport _report({
   FeedbackPriority priority = FeedbackPriority.none,
   String? category,
   DateTime? createdAt,
-}) =>
-    FeedbackReport(
-      title: 't',
-      description: '',
-      screenshotPng: Uint8List(0),
-      fields: fields,
-      metadata: metadata,
-      reporter: reporter,
-      priority: priority,
-      category: category,
-      createdAt: createdAt,
-    );
+}) => FeedbackReport(
+  title: 't',
+  description: '',
+  screenshotPng: Uint8List(0),
+  fields: fields,
+  metadata: metadata,
+  reporter: reporter,
+  priority: priority,
+  category: category,
+  createdAt: createdAt,
+);
 
 void main() {
   group('DefaultFeedbackTemplate', () {

--- a/packages/wise_feedback/test/transport/linear_direct_transport_test.dart
+++ b/packages/wise_feedback/test/transport/linear_direct_transport_test.dart
@@ -199,7 +199,7 @@ void main() {
       );
     });
 
-    test('renders context and maps priority into issueCreate', () async {
+    test('uses the report body verbatim and maps priority', () async {
       Map<String, dynamic>? issueVars;
       final client = MockClient((request) async {
         if (request.method == 'PUT') {
@@ -237,14 +237,13 @@ void main() {
         );
       });
 
+      // The template renders the body; the transport passes it through and
+      // appends the screenshot.
       final report = FeedbackReport(
         title: 'Bug',
-        description: 'broke',
+        description: '## Current Situation\nbroke',
         screenshotPng: Uint8List.fromList([1]),
-        reporter: const FeedbackReporter(name: 'Ann', email: 'a@b.c'),
         priority: FeedbackPriority.high,
-        category: 'Bug',
-        metadata: const {'appVersion': '1.2.3', 'navigation': '/a → /b'},
       );
 
       await LinearDirectTransport(
@@ -255,13 +254,11 @@ void main() {
 
       expect(issueVars?['priority'], FeedbackPriority.high.linearValue);
       final description = issueVars?['description'] as String;
-      expect(description, contains('Reported by'));
-      expect(description, contains('a@b.c'));
-      expect(description, contains('**Category:** Bug'));
-      expect(description, contains('**Priority:** High'));
-      expect(description, contains('appVersion'));
-      expect(description, contains('Recent screens'));
-      expect(description, contains('/a → /b'));
+      expect(description, contains('## Current Situation\nbroke'));
+      expect(
+        description,
+        contains('![screenshot](https://assets.example/a.png)'),
+      );
     });
   });
 }

--- a/packages/wise_feedback/test/widgets/linear_feedback_test.dart
+++ b/packages/wise_feedback/test/widgets/linear_feedback_test.dart
@@ -223,7 +223,11 @@ void main() {
       final report = transport.sent.single;
       expect(report.metadata['platform'], 'test');
       expect(report.metadata['appVersion'], '9.9');
-      expect(report.metadata['navigation'], '/home → /settings');
+      expect(report.metadata[FeedbackReport.navigationKey], [
+        '/home',
+        '/settings',
+      ]);
+      expect(report.description, contains('/home → /settings'));
       expect(report.reporter?.email, 'me@x.com');
     });
   });

--- a/packages/wise_feedback/test/widgets/linear_feedback_test.dart
+++ b/packages/wise_feedback/test/widgets/linear_feedback_test.dart
@@ -39,12 +39,17 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byKey(const Key('wise_feedback_title')), findsOneWidget);
+      expect(
+        find.byKey(const Key('wise_feedback_field_description')),
+        findsOneWidget,
+      );
+
       await tester.enterText(
         find.byKey(const Key('wise_feedback_title')),
         'E2E title',
       );
       await tester.enterText(
-        find.byKey(const Key('wise_feedback_description')),
+        find.byKey(const Key('wise_feedback_field_description')),
         'E2E desc',
       );
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
@@ -57,7 +62,8 @@ void main() {
 
       expect(transport.sent, hasLength(1));
       expect(transport.sent.single.title, 'E2E title');
-      expect(transport.sent.single.description, 'E2E desc');
+      expect(transport.sent.single.fields['description'], 'E2E desc');
+      expect(transport.sent.single.description, contains('E2E desc'));
       expect(transport.sent.single.screenshotPng, isNotEmpty);
     });
 
@@ -81,7 +87,7 @@ void main() {
       await tester.tap(find.byKey(const Key('wise_feedback_fab')));
       await tester.pumpAndSettle();
       await tester.enterText(
-        find.byKey(const Key('wise_feedback_description')),
+        find.byKey(const Key('wise_feedback_field_description')),
         'broken',
       );
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
@@ -164,7 +170,7 @@ void main() {
       await tester.tap(find.byKey(const Key('wise_feedback_fab')));
       await tester.pumpAndSettle();
       await tester.enterText(
-        find.byKey(const Key('wise_feedback_description')),
+        find.byKey(const Key('wise_feedback_field_description')),
         'E2E desc',
       );
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));
@@ -203,7 +209,7 @@ void main() {
       await tester.tap(find.byKey(const Key('wise_feedback_fab')));
       await tester.pumpAndSettle();
       await tester.enterText(
-        find.byKey(const Key('wise_feedback_description')),
+        find.byKey(const Key('wise_feedback_field_description')),
         'ctx',
       );
       await tester.tap(find.byKey(const Key('wise_feedback_submit')));


### PR DESCRIPTION
Stacked on #73. Makes the form fields and the rendered issue body configurable via a `FeedbackTemplate`.

### What's new
- `FeedbackTemplate` abstraction — defines the form's fields and how a report renders to the Linear issue body.
- `DefaultFeedbackTemplate` — unchanged behavior (single description + context section).
- `BugReportTemplate` — structured **Current Situation** / **Desired Situation** inputs, **Steps to Reproduce** filled from the navigation breadcrumb, and **Context** (environment, reporter, date & time) filled automatically.
- `FeedbackReport` gains `fields` and `createdAt`; body rendering moved out of the transport into the template.

Backward-compatible (defaults to `DefaultFeedbackTemplate`). Bumps to **0.3.0**.

### Testing
The latest changes can be tested in the **`test/wise-feedback-sandbox`** branch (it uses `BugReportTemplate`).