### PR TITLE
Feature/wise feedback modern UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,8 +71,25 @@ still fail CI.
 ## Stacked PRs
 
 The `gh stack` extension (`gh stack view` / `rebase` / `submit`) manages the
-branch chains here. After the bottom PR merges, `gh stack rebase` cascades the
-rest; `gh stack rebase --abort` restores every branch if a rebase goes wrong.
+branch chains here — reach for it before rebasing anything by hand. After the
+bottom PR merges, `gh stack rebase` cascades the rest; `gh stack rebase --abort`
+restores every branch if a rebase goes wrong.
+
+**If you do rebase by hand, `git rebase <parent>` is the wrong command.** PRs
+here land rebase-merged, so the parent's commits reach `main` with new SHAs. The
+child branch still carries the originals, and any that were conflict-resolved on
+the way in no longer match by patch-id — so git cannot tell they are already
+upstream and replays them onto a base that has them, conflict by conflict.
+Rebase the child's *own* commits instead:
+
+```bash
+git rebase --onto <new-parent-tip> <old-parent-tip>
+```
+
+`<old-parent-tip>` is the parent commit the child was branched from; everything
+above it is the child's real work. Verify the split first with
+`git log --oneline <old-parent-tip>..HEAD` — that should list only the child's
+commits and nothing belonging to the parent.
 
 Two things to watch when the merged PR changed shared API or formatting:
 

--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.0
+
+- Modernized form UI (Crispy design): a header with circular close/submit
+  actions, labelled inputs in soft-bordered 16px-radius boxes, and an indigo
+  brand accent. All colors, radius and labels are themeable via
+  `WiseFeedbackTheme`.
+
 ## 0.3.0
 
 - Configurable issue templates via `FeedbackTemplate`: the template defines the

--- a/packages/wise_feedback/CHANGELOG.md
+++ b/packages/wise_feedback/CHANGELOG.md
@@ -6,6 +6,8 @@
   actions, labelled inputs in soft-bordered 16px-radius boxes, and an indigo
   brand accent. All colors, radius and labels are themeable via
   `WiseFeedbackTheme`.
+- Added a drag handle (grabber) and made the whole form surface (grabber,
+  header, fields) drag the sheet.
 
 ## 0.3.0
 

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -5,9 +5,7 @@ import '../models/feedback_priority.dart';
 import '../models/feedback_status.dart';
 import '../template/feedback_field.dart';
 import '../theme/wise_feedback_theme.dart';
-
-/// Icon and text color of the inline submission error.
-const Color _kErrorColor = Color(0xFFD32F2F);
+import 'widgets/widgets.dart';
 
 /// Callback invoked when the user submits the form.
 ///
@@ -101,9 +99,6 @@ class _FeedbackFormState extends State<FeedbackForm> {
   Widget build(BuildContext context) {
     final theme = widget.theme;
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
-    // Everything lives in one scroll view driven by the sheet's
-    // scrollController (with always-scrollable physics) so the whole surface —
-    // grabber, header and fields — can drag the sheet.
     return ColoredBox(
       color: theme.backgroundColor,
       child: SingleChildScrollView(
@@ -113,48 +108,36 @@ class _FeedbackFormState extends State<FeedbackForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 8, bottom: 4),
-              child: Center(
-                child: Container(
-                  width: 36,
-                  height: 5,
-                  decoration: BoxDecoration(
-                    color: const Color(0x33000000),
-                    borderRadius: BorderRadius.circular(100),
-                  ),
-                ),
-              ),
-            ),
-            _Header(
+            const FeedbackSheetGrabber(),
+            FeedbackFormHeader(
               theme: theme,
               status: widget.status,
               onClose: widget.onClose,
               onSubmit: _submit,
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
+              padding: const EdgeInsetsDirectional.fromSTEB(16, 4, 16, 0),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
-                  _LabeledField(
+                  FeedbackLabeledField(
                     theme: theme,
                     label: theme.titleHint,
-                    child: _input(
-                      theme,
-                      _titleController,
+                    child: FeedbackTextInput(
+                      theme: theme,
+                      controller: _titleController,
                       fieldKey: const Key('wise_feedback_title'),
                     ),
                   ),
                   for (final field in widget.fields) ...[
                     const SizedBox(height: 16),
-                    _LabeledField(
+                    FeedbackLabeledField(
                       theme: theme,
                       label: field.label,
-                      child: _input(
-                        theme,
-                        _fieldControllers[field.key]!,
+                      child: FeedbackTextInput(
+                        theme: theme,
+                        controller: _fieldControllers[field.key]!,
                         minLines: field.minLines,
                         maxLines: field.maxLines,
                         fieldKey: Key('wise_feedback_field_${field.key}'),
@@ -163,10 +146,10 @@ class _FeedbackFormState extends State<FeedbackForm> {
                   ],
                   if (widget.showPriority) ...[
                     const SizedBox(height: 16),
-                    _LabeledField(
+                    FeedbackLabeledField(
                       theme: theme,
                       label: theme.priorityLabel,
-                      child: _dropdown<FeedbackPriority>(
+                      child: FeedbackDropdown<FeedbackPriority>(
                         theme: theme,
                         value: _priority,
                         fieldKey: const Key('wise_feedback_priority'),
@@ -182,10 +165,10 @@ class _FeedbackFormState extends State<FeedbackForm> {
                   ],
                   if (widget.categories case final List<String> categories) ...[
                     const SizedBox(height: 16),
-                    _LabeledField(
+                    FeedbackLabeledField(
                       theme: theme,
                       label: theme.categoryLabel,
-                      child: _dropdown<String>(
+                      child: FeedbackDropdown<String>(
                         theme: theme,
                         value: _category,
                         fieldKey: const Key('wise_feedback_category'),
@@ -197,31 +180,11 @@ class _FeedbackFormState extends State<FeedbackForm> {
                   ],
                   ValueListenableBuilder<FeedbackStatus>(
                     valueListenable: widget.status,
-                    builder: (context, status, _) {
-                      if (status is! FeedbackFailure) {
-                        return const SizedBox.shrink();
-                      }
-                      return Padding(
-                        padding: const EdgeInsets.only(top: 12),
-                        child: Row(
-                          key: const Key('wise_feedback_error'),
-                          children: [
-                            const Icon(
-                              Icons.error_outline,
-                              color: _kErrorColor,
-                              size: 18,
-                            ),
-                            const SizedBox(width: 8),
-                            Expanded(
-                              child: Text(
-                                theme.messageForError(status.error),
-                                style: const TextStyle(color: _kErrorColor),
-                              ),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
+                    builder: (context, status, _) => status is FeedbackFailure
+                        ? FeedbackErrorMessage(
+                            message: theme.messageForError(status.error),
+                          )
+                        : const SizedBox.shrink(),
                   ),
                 ],
               ),
@@ -229,204 +192,6 @@ class _FeedbackFormState extends State<FeedbackForm> {
           ],
         ),
       ),
-    );
-  }
-
-  Widget _input(
-    WiseFeedbackTheme theme,
-    TextEditingController controller, {
-    int minLines = 1,
-    int maxLines = 1,
-    Key? fieldKey,
-  }) {
-    return TextField(
-      key: fieldKey,
-      controller: controller,
-      textCapitalization: TextCapitalization.sentences,
-      minLines: minLines,
-      maxLines: maxLines,
-      cursorColor: theme.primaryColor,
-      style: TextStyle(
-        fontSize: 17,
-        letterSpacing: -0.43,
-        color: theme.textColor,
-      ),
-      decoration: InputDecoration(
-        isCollapsed: true,
-        border: InputBorder.none,
-        hintStyle: TextStyle(color: theme.hintColor, fontSize: 17),
-      ),
-    );
-  }
-
-  Widget _dropdown<T>({
-    required WiseFeedbackTheme theme,
-    required T? value,
-    required Map<T, String> items,
-    required ValueChanged<T?> onChanged,
-    required Key fieldKey,
-    String? hint,
-  }) {
-    return DropdownButtonHideUnderline(
-      child: DropdownButton<T>(
-        key: fieldKey,
-        value: value,
-        isExpanded: true,
-        isDense: true,
-        hint: hint == null
-            ? null
-            : Text(
-                hint,
-                style: TextStyle(color: theme.hintColor, fontSize: 17),
-              ),
-        icon: Icon(Icons.keyboard_arrow_down_rounded, color: theme.hintColor),
-        style: TextStyle(fontSize: 17, color: theme.textColor),
-        onChanged: onChanged,
-        items: [
-          for (final entry in items.entries)
-            DropdownMenuItem<T>(value: entry.key, child: Text(entry.value)),
-        ],
-      ),
-    );
-  }
-}
-
-/// The sticky header: close button, centered title, brand submit button.
-class _Header extends StatelessWidget {
-  const _Header({
-    required this.theme,
-    required this.status,
-    required this.onClose,
-    required this.onSubmit,
-  });
-
-  final WiseFeedbackTheme theme;
-  final ValueListenable<FeedbackStatus> status;
-  final VoidCallback? onClose;
-  final VoidCallback onSubmit;
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-      child: Row(
-        children: [
-          _CircleButton(
-            buttonKey: const Key('wise_feedback_close'),
-            background: theme.iconButtonColor,
-            icon: Icons.close_rounded,
-            iconColor: theme.labelColor,
-            onTap: onClose,
-          ),
-          Expanded(
-            child: Text(
-              theme.sheetTitle,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.w600,
-                color: theme.textColor,
-              ),
-            ),
-          ),
-          ValueListenableBuilder<FeedbackStatus>(
-            valueListenable: status,
-            builder: (context, status, _) => _CircleButton(
-              buttonKey: const Key('wise_feedback_submit'),
-              background: theme.primaryColor,
-              icon: Icons.check_rounded,
-              iconColor: Colors.white,
-              loading: status.isSubmitting,
-              onTap: status.isSubmitting ? null : onSubmit,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _CircleButton extends StatelessWidget {
-  const _CircleButton({
-    required this.buttonKey,
-    required this.background,
-    required this.icon,
-    required this.iconColor,
-    required this.onTap,
-    this.loading = false,
-  });
-
-  final Key buttonKey;
-  final Color background;
-  final IconData icon;
-  final Color iconColor;
-  final VoidCallback? onTap;
-  final bool loading;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox.square(
-      dimension: 44,
-      child: Material(
-        key: buttonKey,
-        color: background,
-        shape: const CircleBorder(),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onTap: onTap,
-          child: Center(
-            child: loading
-                ? SizedBox.square(
-                    dimension: 18,
-                    child: CircularProgressIndicator(
-                      strokeWidth: 2,
-                      color: iconColor,
-                    ),
-                  )
-                : Icon(icon, size: 20, color: iconColor),
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-/// A label above a bordered, rounded input box.
-class _LabeledField extends StatelessWidget {
-  const _LabeledField({
-    required this.theme,
-    required this.label,
-    required this.child,
-  });
-
-  final WiseFeedbackTheme theme;
-  final String label;
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(left: 12, bottom: 4),
-          child: Text(
-            label,
-            style: TextStyle(fontSize: 15, color: theme.labelColor),
-          ),
-        ),
-        Container(
-          constraints: const BoxConstraints(minHeight: 52),
-          alignment: Alignment.centerLeft,
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-          decoration: BoxDecoration(
-            color: theme.fieldFillColor,
-            borderRadius: BorderRadius.circular(theme.fieldRadius),
-            border: Border.all(color: theme.fieldBorderColor),
-          ),
-          child: child,
-        ),
-      ],
     );
   }
 }

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -101,20 +101,39 @@ class _FeedbackFormState extends State<FeedbackForm> {
   Widget build(BuildContext context) {
     final theme = widget.theme;
     final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
+    // Everything lives in one scroll view driven by the sheet's
+    // scrollController (with always-scrollable physics) so the whole surface —
+    // grabber, header and fields — can drag the sheet.
     return ColoredBox(
       color: theme.backgroundColor,
-      child: Column(
-        children: [
-          _Header(
-            theme: theme,
-            status: widget.status,
-            onClose: widget.onClose,
-            onSubmit: _submit,
-          ),
-          Expanded(
-            child: SingleChildScrollView(
-              controller: widget.scrollController,
-              padding: EdgeInsets.fromLTRB(16, 4, 16, 16 + bottomInset),
+      child: SingleChildScrollView(
+        controller: widget.scrollController,
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: EdgeInsets.only(bottom: 16 + bottomInset),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(top: 8, bottom: 4),
+              child: Center(
+                child: Container(
+                  width: 36,
+                  height: 5,
+                  decoration: BoxDecoration(
+                    color: const Color(0x33000000),
+                    borderRadius: BorderRadius.circular(100),
+                  ),
+                ),
+              ),
+            ),
+            _Header(
+              theme: theme,
+              status: widget.status,
+              onClose: widget.onClose,
+              onSubmit: _submit,
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 4, 16, 0),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -207,8 +226,8 @@ class _FeedbackFormState extends State<FeedbackForm> {
                 ],
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -6,9 +6,6 @@ import '../models/feedback_status.dart';
 import '../template/feedback_field.dart';
 import '../theme/wise_feedback_theme.dart';
 
-/// Wisemen accent used for the submit button.
-const Color _kAccent = Color(0xFF009687);
-
 /// Icon and text color of the inline submission error.
 const Color _kErrorColor = Color(0xFFD32F2F);
 
@@ -24,8 +21,8 @@ const Color _kErrorColor = Color(0xFFD32F2F);
 /// [FeedbackFailure] it stays open and shows the error inline.
 typedef FeedbackFormSubmit = Future<void> Function(Map<String, dynamic> values);
 
-/// The built-in feedback form: a title, the template's fields, and optional
-/// priority/category selectors.
+/// The built-in feedback form: a header with close/submit actions, the
+/// template's labelled fields, and optional priority/category selectors.
 class FeedbackForm extends StatefulWidget {
   /// Creates the form.
   const FeedbackForm({
@@ -33,6 +30,7 @@ class FeedbackForm extends StatefulWidget {
     required this.theme,
     required this.status,
     required this.fields,
+    this.onClose,
     this.scrollController,
     this.showPriority = false,
     this.categories,
@@ -41,6 +39,9 @@ class FeedbackForm extends StatefulWidget {
 
   /// Called with the field values (in extras) on submit.
   final FeedbackFormSubmit onSubmit;
+
+  /// Dismisses the sheet without submitting (the header close button).
+  final VoidCallback? onClose;
 
   /// Visual configuration.
   final WiseFeedbackTheme theme;
@@ -99,125 +100,314 @@ class _FeedbackFormState extends State<FeedbackForm> {
   @override
   Widget build(BuildContext context) {
     final theme = widget.theme;
-    final bottomInset =
-        MediaQuery.viewInsetsOf(context).bottom +
-        MediaQuery.viewPaddingOf(context).bottom;
+    final bottomInset = MediaQuery.viewInsetsOf(context).bottom;
     return ColoredBox(
       color: theme.backgroundColor,
-      child: SingleChildScrollView(
-        controller: widget.scrollController,
-        padding: const EdgeInsets.all(16).copyWith(bottom: 16 + bottomInset),
-        child: ValueListenableBuilder<FeedbackStatus>(
-          valueListenable: widget.status,
-          builder: (context, status, _) {
-            final errorText = status is FeedbackFailure
-                ? theme.messageForError(status.error)
-                : null;
-            return Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              spacing: 12,
-              children: [
-                TextField(
-                  key: const Key('wise_feedback_title'),
-                  controller: _titleController,
-                  textCapitalization: TextCapitalization.sentences,
-                  decoration: InputDecoration(
-                    labelText: theme.titleHint,
-                    border: const OutlineInputBorder(),
-                  ),
-                ),
-                for (final field in widget.fields)
-                  TextField(
-                    key: Key('wise_feedback_field_${field.key}'),
-                    controller: _fieldControllers[field.key],
-                    textCapitalization: TextCapitalization.sentences,
-                    minLines: field.minLines,
-                    maxLines: field.maxLines,
-                    decoration: InputDecoration(
-                      labelText: field.label,
-                      border: const OutlineInputBorder(),
-                      alignLabelWithHint: true,
+      child: Column(
+        children: [
+          _Header(
+            theme: theme,
+            status: widget.status,
+            onClose: widget.onClose,
+            onSubmit: _submit,
+          ),
+          Expanded(
+            child: SingleChildScrollView(
+              controller: widget.scrollController,
+              padding: EdgeInsets.fromLTRB(16, 4, 16, 16 + bottomInset),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  _LabeledField(
+                    theme: theme,
+                    label: theme.titleHint,
+                    child: _input(
+                      theme,
+                      _titleController,
+                      fieldKey: const Key('wise_feedback_title'),
                     ),
                   ),
-                if (widget.showPriority)
-                  DropdownButtonFormField<FeedbackPriority>(
-                    key: const Key('wise_feedback_priority'),
-                    initialValue: _priority,
-                    decoration: InputDecoration(
-                      labelText: theme.priorityLabel,
-                      border: const OutlineInputBorder(),
-                    ),
-                    items: [
-                      for (final priority in FeedbackPriority.values)
-                        DropdownMenuItem(
-                          value: priority,
-                          child: Text(priority.label),
-                        ),
-                    ],
-                    onChanged: (value) => setState(
-                      () => _priority = value ?? FeedbackPriority.none,
-                    ),
-                  ),
-                if (widget.categories case final List<String> categories)
-                  DropdownButtonFormField<String>(
-                    key: const Key('wise_feedback_category'),
-                    initialValue: _category,
-                    decoration: InputDecoration(
-                      labelText: theme.categoryLabel,
-                      border: const OutlineInputBorder(),
-                    ),
-                    items: [
-                      for (final category in categories)
-                        DropdownMenuItem(
-                          value: category,
-                          child: Text(category),
-                        ),
-                    ],
-                    onChanged: (value) => setState(() => _category = value),
-                  ),
-                if (errorText != null)
-                  Row(
-                    key: const Key('wise_feedback_error'),
-                    spacing: 8,
-                    children: [
-                      const Icon(
-                        Icons.error_outline,
-                        color: _kErrorColor,
-                        size: 18,
+                  for (final field in widget.fields) ...[
+                    const SizedBox(height: 16),
+                    _LabeledField(
+                      theme: theme,
+                      label: field.label,
+                      child: _input(
+                        theme,
+                        _fieldControllers[field.key]!,
+                        minLines: field.minLines,
+                        maxLines: field.maxLines,
+                        fieldKey: Key('wise_feedback_field_${field.key}'),
                       ),
-                      Expanded(
-                        child: Text(
-                          errorText,
-                          style: const TextStyle(color: _kErrorColor),
+                    ),
+                  ],
+                  if (widget.showPriority) ...[
+                    const SizedBox(height: 16),
+                    _LabeledField(
+                      theme: theme,
+                      label: theme.priorityLabel,
+                      child: _dropdown<FeedbackPriority>(
+                        theme: theme,
+                        value: _priority,
+                        fieldKey: const Key('wise_feedback_priority'),
+                        items: {
+                          for (final priority in FeedbackPriority.values)
+                            priority: priority.label,
+                        },
+                        onChanged: (value) => setState(
+                          () => _priority = value ?? FeedbackPriority.none,
                         ),
                       ),
-                    ],
-                  ),
-                Padding(
-                  padding: const EdgeInsets.only(top: 4),
-                  child: FilledButton(
-                    key: const Key('wise_feedback_submit'),
-                    style: FilledButton.styleFrom(
-                      backgroundColor: _kAccent,
                     ),
-                    onPressed: status.isSubmitting ? null : _submit,
-                    child: status.isSubmitting
-                        ? const SizedBox.square(
-                            dimension: 20,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
+                  ],
+                  if (widget.categories case final List<String> categories) ...[
+                    const SizedBox(height: 16),
+                    _LabeledField(
+                      theme: theme,
+                      label: theme.categoryLabel,
+                      child: _dropdown<String>(
+                        theme: theme,
+                        value: _category,
+                        fieldKey: const Key('wise_feedback_category'),
+                        hint: theme.categoryLabel,
+                        items: {for (final c in categories) c: c},
+                        onChanged: (value) => setState(() => _category = value),
+                      ),
+                    ),
+                  ],
+                  ValueListenableBuilder<FeedbackStatus>(
+                    valueListenable: widget.status,
+                    builder: (context, status, _) {
+                      if (status is! FeedbackFailure) {
+                        return const SizedBox.shrink();
+                      }
+                      return Padding(
+                        padding: const EdgeInsets.only(top: 12),
+                        child: Row(
+                          key: const Key('wise_feedback_error'),
+                          children: [
+                            const Icon(
+                              Icons.error_outline,
+                              color: _kErrorColor,
+                              size: 18,
                             ),
-                          )
-                        : Text(theme.submitLabel),
+                            const SizedBox(width: 8),
+                            Expanded(
+                              child: Text(
+                                theme.messageForError(status.error),
+                                style: const TextStyle(color: _kErrorColor),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
                   ),
-                ),
-              ],
-            );
-          },
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _input(
+    WiseFeedbackTheme theme,
+    TextEditingController controller, {
+    int minLines = 1,
+    int maxLines = 1,
+    Key? fieldKey,
+  }) {
+    return TextField(
+      key: fieldKey,
+      controller: controller,
+      textCapitalization: TextCapitalization.sentences,
+      minLines: minLines,
+      maxLines: maxLines,
+      cursorColor: theme.primaryColor,
+      style: TextStyle(
+        fontSize: 17,
+        letterSpacing: -0.43,
+        color: theme.textColor,
+      ),
+      decoration: InputDecoration(
+        isCollapsed: true,
+        border: InputBorder.none,
+        hintStyle: TextStyle(color: theme.hintColor, fontSize: 17),
+      ),
+    );
+  }
+
+  Widget _dropdown<T>({
+    required WiseFeedbackTheme theme,
+    required T? value,
+    required Map<T, String> items,
+    required ValueChanged<T?> onChanged,
+    required Key fieldKey,
+    String? hint,
+  }) {
+    return DropdownButtonHideUnderline(
+      child: DropdownButton<T>(
+        key: fieldKey,
+        value: value,
+        isExpanded: true,
+        isDense: true,
+        hint: hint == null
+            ? null
+            : Text(
+                hint,
+                style: TextStyle(color: theme.hintColor, fontSize: 17),
+              ),
+        icon: Icon(Icons.keyboard_arrow_down_rounded, color: theme.hintColor),
+        style: TextStyle(fontSize: 17, color: theme.textColor),
+        onChanged: onChanged,
+        items: [
+          for (final entry in items.entries)
+            DropdownMenuItem<T>(value: entry.key, child: Text(entry.value)),
+        ],
+      ),
+    );
+  }
+}
+
+/// The sticky header: close button, centered title, brand submit button.
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.theme,
+    required this.status,
+    required this.onClose,
+    required this.onSubmit,
+  });
+
+  final WiseFeedbackTheme theme;
+  final ValueListenable<FeedbackStatus> status;
+  final VoidCallback? onClose;
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+      child: Row(
+        children: [
+          _CircleButton(
+            buttonKey: const Key('wise_feedback_close'),
+            background: theme.iconButtonColor,
+            icon: Icons.close_rounded,
+            iconColor: theme.labelColor,
+            onTap: onClose,
+          ),
+          Expanded(
+            child: Text(
+              theme.sheetTitle,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: theme.textColor,
+              ),
+            ),
+          ),
+          ValueListenableBuilder<FeedbackStatus>(
+            valueListenable: status,
+            builder: (context, status, _) => _CircleButton(
+              buttonKey: const Key('wise_feedback_submit'),
+              background: theme.primaryColor,
+              icon: Icons.check_rounded,
+              iconColor: Colors.white,
+              loading: status.isSubmitting,
+              onTap: status.isSubmitting ? null : onSubmit,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CircleButton extends StatelessWidget {
+  const _CircleButton({
+    required this.buttonKey,
+    required this.background,
+    required this.icon,
+    required this.iconColor,
+    required this.onTap,
+    this.loading = false,
+  });
+
+  final Key buttonKey;
+  final Color background;
+  final IconData icon;
+  final Color iconColor;
+  final VoidCallback? onTap;
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 44,
+      child: Material(
+        key: buttonKey,
+        color: background,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Center(
+            child: loading
+                ? SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: iconColor,
+                    ),
+                  )
+                : Icon(icon, size: 20, color: iconColor),
+          ),
         ),
       ),
+    );
+  }
+}
+
+/// A label above a bordered, rounded input box.
+class _LabeledField extends StatelessWidget {
+  const _LabeledField({
+    required this.theme,
+    required this.label,
+    required this.child,
+  });
+
+  final WiseFeedbackTheme theme;
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(left: 12, bottom: 4),
+          child: Text(
+            label,
+            style: TextStyle(fontSize: 15, color: theme.labelColor),
+          ),
+        ),
+        Container(
+          constraints: const BoxConstraints(minHeight: 52),
+          alignment: Alignment.centerLeft,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            color: theme.fieldFillColor,
+            borderRadius: BorderRadius.circular(theme.fieldRadius),
+            border: Border.all(color: theme.fieldBorderColor),
+          ),
+          child: child,
+        ),
+      ],
     );
   }
 }

--- a/packages/wise_feedback/lib/src/screens/feedback_form.dart
+++ b/packages/wise_feedback/lib/src/screens/feedback_form.dart
@@ -108,7 +108,7 @@ class _FeedbackFormState extends State<FeedbackForm> {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            const FeedbackSheetGrabber(),
+            FeedbackSheetGrabber(theme: theme),
             FeedbackFormHeader(
               theme: theme,
               status: widget.status,
@@ -182,6 +182,7 @@ class _FeedbackFormState extends State<FeedbackForm> {
                     valueListenable: widget.status,
                     builder: (context, status, _) => status is FeedbackFailure
                         ? FeedbackErrorMessage(
+                            theme: theme,
                             message: theme.messageForError(status.error),
                           )
                         : const SizedBox.shrink(),

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_circle_button.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_circle_button.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+/// A round icon button, used for the header's close and submit actions.
+///
+/// Shows a spinner in place of the icon while [loading].
+class FeedbackCircleButton extends StatelessWidget {
+  /// Creates the button.
+  const FeedbackCircleButton({
+    required this.buttonKey,
+    required this.background,
+    required this.icon,
+    required this.iconColor,
+    required this.onTap,
+    this.loading = false,
+    super.key,
+  });
+
+  /// Applied to the tappable surface so tests can target the button.
+  final Key buttonKey;
+
+  /// Fill color of the circle.
+  final Color background;
+
+  /// Glyph rendered in the centre.
+  final IconData icon;
+
+  /// Color of [icon] and of the loading spinner.
+  final Color iconColor;
+
+  /// Tap handler, or null to disable the button.
+  final VoidCallback? onTap;
+
+  /// Whether to replace [icon] with a progress indicator.
+  final bool loading;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox.square(
+      dimension: 44,
+      child: Material(
+        key: buttonKey,
+        color: background,
+        shape: const CircleBorder(),
+        clipBehavior: Clip.antiAlias,
+        child: InkWell(
+          onTap: onTap,
+          child: Center(
+            child: loading
+                ? SizedBox.square(
+                    dimension: 18,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      color: iconColor,
+                    ),
+                  )
+                : Icon(icon, size: 20, color: iconColor),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_dropdown.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_dropdown.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/wise_feedback_theme.dart';
+
+/// A borderless dropdown sized to sit inside a labelled field box.
+///
+/// [items] maps each selectable value to the label shown for it.
+class FeedbackDropdown<T> extends StatelessWidget {
+  /// Creates the dropdown.
+  const FeedbackDropdown({
+    required this.theme,
+    required this.value,
+    required this.items,
+    required this.onChanged,
+    required this.fieldKey,
+    this.hint,
+    super.key,
+  });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
+
+  /// Currently selected value, or null when nothing is selected.
+  final T? value;
+
+  /// Selectable values mapped to their display labels.
+  final Map<T, String> items;
+
+  /// Called with the newly selected value.
+  final ValueChanged<T?> onChanged;
+
+  /// Applied to the underlying `DropdownButton` so tests can target it.
+  final Key fieldKey;
+
+  /// Placeholder shown while [value] is null.
+  final String? hint;
+
+  @override
+  Widget build(BuildContext context) {
+    return DropdownButtonHideUnderline(
+      child: DropdownButton<T>(
+        key: fieldKey,
+        value: value,
+        isExpanded: true,
+        isDense: true,
+        hint: hint == null
+            ? null
+            : Text(
+                hint!,
+                style: TextStyle(color: theme.hintColor, fontSize: 17),
+              ),
+        icon: Icon(Icons.keyboard_arrow_down_rounded, color: theme.hintColor),
+        style: TextStyle(fontSize: 17, color: theme.textColor),
+        onChanged: onChanged,
+        items: [
+          for (final entry in items.entries)
+            DropdownMenuItem<T>(value: entry.key, child: Text(entry.value)),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
@@ -1,12 +1,18 @@
 import 'package:flutter/material.dart';
 
-/// Icon and text color of the inline submission error.
-const Color _kErrorColor = Color(0xFFD32F2F);
+import '../../theme/wise_feedback_theme.dart';
 
 /// The inline error shown under the form when a submission fails.
 class FeedbackErrorMessage extends StatelessWidget {
   /// Creates the error row.
-  const FeedbackErrorMessage({required this.message, super.key});
+  const FeedbackErrorMessage({
+    required this.theme,
+    required this.message,
+    super.key,
+  });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
 
   /// Human-readable failure text.
   final String message;
@@ -18,12 +24,12 @@ class FeedbackErrorMessage extends StatelessWidget {
       child: Row(
         key: const Key('wise_feedback_error'),
         children: [
-          const Icon(Icons.error_outline, color: _kErrorColor, size: 18),
+          Icon(Icons.error_outline, color: theme.errorColor, size: 18),
           const SizedBox(width: 8),
           Expanded(
             child: Text(
               message,
-              style: const TextStyle(color: _kErrorColor),
+              style: TextStyle(color: theme.errorColor),
             ),
           ),
         ],

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
@@ -14,7 +14,7 @@ class FeedbackErrorMessage extends StatelessWidget {
   /// Visual configuration.
   final WiseFeedbackTheme theme;
 
-  /// Human-readable failure text.
+  /// Failure text.
   final String message;
 
   @override

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_error_message.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// Icon and text color of the inline submission error.
+const Color _kErrorColor = Color(0xFFD32F2F);
+
+/// The inline error shown under the form when a submission fails.
+class FeedbackErrorMessage extends StatelessWidget {
+  /// Creates the error row.
+  const FeedbackErrorMessage({required this.message, super.key});
+
+  /// Human-readable failure text.
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 12),
+      child: Row(
+        key: const Key('wise_feedback_error'),
+        children: [
+          const Icon(Icons.error_outline, color: _kErrorColor, size: 18),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(color: _kErrorColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_form_header.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_form_header.dart
@@ -61,7 +61,7 @@ class FeedbackFormHeader extends StatelessWidget {
               buttonKey: const Key('wise_feedback_submit'),
               background: theme.primaryColor,
               icon: Icons.check_rounded,
-              iconColor: Colors.white,
+              iconColor: theme.onAccentColor,
               loading: status.isSubmitting,
               onTap: status.isSubmitting ? null : onSubmit,
             ),

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_form_header.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_form_header.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../../models/feedback_status.dart';
+import '../../theme/wise_feedback_theme.dart';
+import 'feedback_circle_button.dart';
+
+/// The form's header: close button, centred title, brand submit button.
+///
+/// The submit button tracks [status], showing a spinner and refusing taps while
+/// a report is in flight.
+class FeedbackFormHeader extends StatelessWidget {
+  /// Creates the header.
+  const FeedbackFormHeader({
+    required this.theme,
+    required this.status,
+    required this.onClose,
+    required this.onSubmit,
+    super.key,
+  });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
+
+  /// Submission state driving the submit button.
+  final ValueListenable<FeedbackStatus> status;
+
+  /// Dismisses the sheet without submitting, or null to disable the button.
+  final VoidCallback? onClose;
+
+  /// Submits the report.
+  final VoidCallback onSubmit;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsetsDirectional.fromSTEB(16, 12, 16, 8),
+      child: Row(
+        children: [
+          FeedbackCircleButton(
+            buttonKey: const Key('wise_feedback_close'),
+            background: theme.iconButtonColor,
+            icon: Icons.close_rounded,
+            iconColor: theme.labelColor,
+            onTap: onClose,
+          ),
+          Expanded(
+            child: Text(
+              theme.sheetTitle,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.w600,
+                color: theme.textColor,
+              ),
+            ),
+          ),
+          ValueListenableBuilder<FeedbackStatus>(
+            valueListenable: status,
+            builder: (context, status, _) => FeedbackCircleButton(
+              buttonKey: const Key('wise_feedback_submit'),
+              background: theme.primaryColor,
+              icon: Icons.check_rounded,
+              iconColor: Colors.white,
+              loading: status.isSubmitting,
+              onTap: status.isSubmitting ? null : onSubmit,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_labeled_field.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_labeled_field.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/wise_feedback_theme.dart';
+
+/// A label above a bordered, rounded box wrapping [child].
+class FeedbackLabeledField extends StatelessWidget {
+  /// Creates the labelled field.
+  const FeedbackLabeledField({
+    required this.theme,
+    required this.label,
+    required this.child,
+    super.key,
+  });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
+
+  /// Text shown above the box.
+  final String label;
+
+  /// The input rendered inside the box.
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsetsDirectional.only(start: 12, bottom: 4),
+          child: Text(
+            label,
+            style: TextStyle(fontSize: 15, color: theme.labelColor),
+          ),
+        ),
+        Container(
+          constraints: const BoxConstraints(minHeight: 52),
+          alignment: AlignmentDirectional.centerStart,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+          decoration: BoxDecoration(
+            color: theme.fieldFillColor,
+            borderRadius: BorderRadius.circular(theme.fieldRadius),
+            border: Border.all(color: theme.fieldBorderColor),
+          ),
+          child: child,
+        ),
+      ],
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_sheet_grabber.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_sheet_grabber.dart
@@ -1,25 +1,27 @@
 import 'package:flutter/material.dart';
 
-/// Fill of the grabber pill.
-const Color _kGrabberColor = Color(0x33000000);
+import '../../theme/wise_feedback_theme.dart';
 
 /// The pill at the top of the sheet that signals it can be dragged.
 class FeedbackSheetGrabber extends StatelessWidget {
   /// Creates the grabber.
-  const FeedbackSheetGrabber({super.key});
+  const FeedbackSheetGrabber({required this.theme, super.key});
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
 
   @override
   Widget build(BuildContext context) {
-    return const Padding(
-      padding: EdgeInsets.only(top: 8, bottom: 4),
+    return Padding(
+      padding: const EdgeInsets.only(top: 8, bottom: 4),
       child: Center(
         child: SizedBox(
           width: 36,
           height: 5,
           child: DecoratedBox(
             decoration: BoxDecoration(
-              color: _kGrabberColor,
-              borderRadius: BorderRadius.all(Radius.circular(100)),
+              color: theme.grabberColor,
+              borderRadius: const BorderRadius.all(Radius.circular(100)),
             ),
           ),
         ),

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_sheet_grabber.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_sheet_grabber.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+/// Fill of the grabber pill.
+const Color _kGrabberColor = Color(0x33000000);
+
+/// The pill at the top of the sheet that signals it can be dragged.
+class FeedbackSheetGrabber extends StatelessWidget {
+  /// Creates the grabber.
+  const FeedbackSheetGrabber({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Padding(
+      padding: EdgeInsets.only(top: 8, bottom: 4),
+      child: Center(
+        child: SizedBox(
+          width: 36,
+          height: 5,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: _kGrabberColor,
+              borderRadius: BorderRadius.all(Radius.circular(100)),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/feedback_text_input.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/feedback_text_input.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../theme/wise_feedback_theme.dart';
+
+/// A borderless text field sized to sit inside a labelled field box.
+class FeedbackTextInput extends StatelessWidget {
+  /// Creates the input.
+  const FeedbackTextInput({
+    required this.theme,
+    required this.controller,
+    this.minLines = 1,
+    this.maxLines = 1,
+    this.fieldKey,
+    super.key,
+  });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
+
+  /// Holds the edited text.
+  final TextEditingController controller;
+
+  /// Minimum number of visible lines.
+  final int minLines;
+
+  /// Maximum number of visible lines.
+  final int maxLines;
+
+  /// Applied to the underlying `TextField` so tests can target it.
+  final Key? fieldKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return TextField(
+      key: fieldKey,
+      controller: controller,
+      textCapitalization: TextCapitalization.sentences,
+      minLines: minLines,
+      maxLines: maxLines,
+      cursorColor: theme.primaryColor,
+      style: TextStyle(fontSize: 17, color: theme.textColor),
+      decoration: InputDecoration(
+        isCollapsed: true,
+        border: InputBorder.none,
+        hintStyle: TextStyle(color: theme.hintColor, fontSize: 17),
+      ),
+    );
+  }
+}

--- a/packages/wise_feedback/lib/src/screens/widgets/widgets.dart
+++ b/packages/wise_feedback/lib/src/screens/widgets/widgets.dart
@@ -1,0 +1,7 @@
+export 'feedback_circle_button.dart';
+export 'feedback_dropdown.dart';
+export 'feedback_error_message.dart';
+export 'feedback_form_header.dart';
+export 'feedback_labeled_field.dart';
+export 'feedback_sheet_grabber.dart';
+export 'feedback_text_input.dart';

--- a/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
+++ b/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
@@ -4,13 +4,21 @@ import '../models/feedback_exception.dart';
 
 /// Text and surface configuration for the built-in feedback form.
 ///
-/// Styling is intentionally opinionated (Wisemen defaults); only the surface
-/// [backgroundColor] and the display strings are configurable. The strings are
-/// placeholders pending localization in a follow-up.
+/// Defaults follow a modern, Crispy-style design: labelled inputs with a soft
+/// border and 16px corners, and an indigo brand accent.
 class WiseFeedbackTheme {
   /// Creates a theme. All parameters have sensible defaults.
   const WiseFeedbackTheme({
+    this.primaryColor = const Color(0xFF4F46E5),
     this.backgroundColor = Colors.white,
+    this.fieldFillColor = Colors.white,
+    this.fieldBorderColor = const Color(0xFFE3E8EF),
+    this.labelColor = const Color(0xFF364152),
+    this.textColor = const Color(0xFF121926),
+    this.hintColor = const Color(0xFF9AA4B2),
+    this.iconButtonColor = const Color(0xFFEEF2F6),
+    this.fieldRadius = 16,
+    this.sheetTitle = 'Report a bug',
     this.titleHint = 'Title',
     this.descriptionHint = 'Description',
     this.submitLabel = 'Report bug',
@@ -20,8 +28,35 @@ class WiseFeedbackTheme {
     this.genericErrorMessage = 'Something went wrong. Please try again.',
   });
 
+  /// Accent color: submit button, focused field cursor.
+  final Color primaryColor;
+
   /// Background color of the form surface.
   final Color backgroundColor;
+
+  /// Fill color of input boxes.
+  final Color fieldFillColor;
+
+  /// Border color of input boxes.
+  final Color fieldBorderColor;
+
+  /// Color of field labels.
+  final Color labelColor;
+
+  /// Color of entered text.
+  final Color textColor;
+
+  /// Color of placeholder/hint text.
+  final Color hintColor;
+
+  /// Background of the circular close (and neutral icon) buttons.
+  final Color iconButtonColor;
+
+  /// Corner radius of input boxes.
+  final double fieldRadius;
+
+  /// Title shown in the sheet header.
+  final String sheetTitle;
 
   /// Placeholder/label for the title field.
   final String titleHint;

--- a/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
+++ b/packages/wise_feedback/lib/src/theme/wise_feedback_theme.dart
@@ -17,6 +17,10 @@ class WiseFeedbackTheme {
     this.textColor = const Color(0xFF121926),
     this.hintColor = const Color(0xFF9AA4B2),
     this.iconButtonColor = const Color(0xFFEEF2F6),
+    this.errorColor = const Color(0xFFD32F2F),
+    this.successColor = const Color(0xFF2E7D32),
+    this.grabberColor = const Color(0x33000000),
+    this.onAccentColor = Colors.white,
     this.fieldRadius = 16,
     this.sheetTitle = 'Report a bug',
     this.titleHint = 'Title',
@@ -51,6 +55,19 @@ class WiseFeedbackTheme {
 
   /// Background of the circular close (and neutral icon) buttons.
   final Color iconButtonColor;
+
+  /// Fill for failure surfaces: the inline submission error and the error toast.
+  final Color errorColor;
+
+  /// Fill for the success toast.
+  final Color successColor;
+
+  /// Fill of the pill at the top of the sheet that signals it can be dragged.
+  final Color grabberColor;
+
+  /// Icons and text drawn on top of a [primaryColor], [errorColor] or
+  /// [successColor] fill.
+  final Color onAccentColor;
 
   /// Corner radius of input boxes.
   final double fieldRadius;

--- a/packages/wise_feedback/lib/src/widgets/feedback_toast.dart
+++ b/packages/wise_feedback/lib/src/widgets/feedback_toast.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../theme/wise_feedback_theme.dart';
+
 /// A self-contained toast rendered in an overlay above the app.
 ///
 /// The overlay above the app has no [Directionality] or [Material], so both
@@ -9,11 +11,15 @@ import 'package:flutter/material.dart';
 class FeedbackToast extends StatelessWidget {
   /// Creates a toast.
   const FeedbackToast({
+    required this.theme,
     required this.message,
     required this.isError,
     required this.onDismiss,
     super.key,
   });
+
+  /// Visual configuration.
+  final WiseFeedbackTheme theme;
 
   /// The text shown in the toast.
   final String message;
@@ -35,9 +41,7 @@ class FeedbackToast extends StatelessWidget {
           child: Container(
             padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
             decoration: BoxDecoration(
-              color: isError
-                  ? const Color(0xFFD32F2F)
-                  : const Color(0xFF2E7D32),
+              color: isError ? theme.errorColor : theme.successColor,
               borderRadius: BorderRadius.circular(8),
             ),
             child: Row(
@@ -45,14 +49,14 @@ class FeedbackToast extends StatelessWidget {
               children: [
                 Icon(
                   isError ? Icons.error_outline : Icons.check_circle_outline,
-                  color: Colors.white,
+                  color: theme.onAccentColor,
                   size: 20,
                 ),
                 const SizedBox(width: 12),
                 Flexible(
                   child: Text(
                     message,
-                    style: const TextStyle(color: Colors.white),
+                    style: TextStyle(color: theme.onAccentColor),
                   ),
                 ),
               ],
@@ -79,7 +83,12 @@ class FeedbackToastPresenter {
 
   /// Inserts a toast into the [Overlay] above [context]; auto-dismisses after
   /// 4 seconds. No-ops if [context] is null or has no ambient overlay.
-  void show(BuildContext? context, String message, {required bool isError}) {
+  void show(
+    BuildContext? context,
+    String message, {
+    required bool isError,
+    required WiseFeedbackTheme theme,
+  }) {
     if (context == null) {
       return;
     }
@@ -110,6 +119,7 @@ class FeedbackToastPresenter {
           right: 16,
           bottom: bottom,
           child: FeedbackToast(
+            theme: theme,
             message: message,
             isError: isError,
             onDismiss: remove,

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -282,6 +282,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         fields: widget.template.fields,
         showPriority: widget.showPriority,
         categories: widget.categories,
+        onClose: () => BetterFeedback.of(context).hide(),
         onSubmit: (values) => _submit(onSubmit, values),
       ),
       child: Builder(

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -282,7 +282,7 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         fields: widget.template.fields,
         showPriority: widget.showPriority,
         categories: widget.categories,
-        onClose: () => BetterFeedback.of(context).hide(),
+        onClose: BetterFeedback.of(context).hide,
         onSubmit: (values) => _submit(onSubmit, values),
       ),
       child: Builder(

--- a/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
+++ b/packages/wise_feedback/lib/src/widgets/linear_feedback.dart
@@ -262,12 +262,14 @@ class _LinearFeedbackState extends State<LinearFeedback> {
         _overlayContext,
         widget.theme.successMessage,
         isError: false,
+        theme: widget.theme,
       );
     } catch (error) {
       _toasts.show(
         _overlayContext,
         widget.theme.messageForError(error),
         isError: true,
+        theme: widget.theme,
       );
     }
   }

--- a/packages/wise_feedback/pubspec.yaml
+++ b/packages/wise_feedback/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wise_feedback
 description: In-app bug reporting for Flutter that files a screenshot, title and description as a Linear issue, via a pluggable transport (direct token or backend proxy).
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 repository: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_feedback
 

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -198,7 +198,7 @@ void main() {
               status: status,
               fields: _fields,
               onClose: () => closed++,
-              onSubmit: (description, {extras}) async {},
+              onSubmit: (values) async {},
             ),
           ),
         ),

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -89,6 +89,35 @@ void main() {
       expect(find.byKey(const Key('wise_feedback_submit')), findsOneWidget);
     });
 
+    testWidgets('paints the inline error with the themed error color', (
+      tester,
+    ) async {
+      const customError = Color(0xFF00FF00);
+      final status = ValueNotifier<FeedbackStatus>(
+        const FeedbackFailure(FeedbackException('Could not send it.')),
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackForm(
+              theme: const WiseFeedbackTheme(errorColor: customError),
+              status: status,
+              fields: _fields,
+              onSubmit: (values) async {},
+            ),
+          ),
+        ),
+      );
+
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byKey(const Key('wise_feedback_error')),
+          matching: find.byType(Icon),
+        ),
+      );
+      expect(icon.color, customError);
+    });
+
     testWidgets('renders a field per template field', (tester) async {
       final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
       await tester.pumpWidget(

--- a/packages/wise_feedback/test/screens/feedback_form_test.dart
+++ b/packages/wise_feedback/test/screens/feedback_form_test.dart
@@ -156,6 +156,31 @@ void main() {
       expect(gotValues?['category'], 'Idea');
     });
 
+    testWidgets('header shows the title and close button fires onClose', (
+      tester,
+    ) async {
+      var closed = 0;
+      final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: FeedbackForm(
+              theme: const WiseFeedbackTheme(sheetTitle: 'Give feedback'),
+              status: status,
+              fields: _fields,
+              onClose: () => closed++,
+              onSubmit: (description, {extras}) async {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Give feedback'), findsOneWidget);
+      await tester.tap(find.byKey(const Key('wise_feedback_close')));
+      await tester.pump();
+      expect(closed, 1);
+    });
+
     testWidgets('hides priority and category by default', (tester) async {
       final status = ValueNotifier<FeedbackStatus>(const FeedbackIdle());
       await tester.pumpWidget(

--- a/packages/wise_feedback/test/widgets/feedback_toast_test.dart
+++ b/packages/wise_feedback/test/widgets/feedback_toast_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wise_feedback/src/theme/wise_feedback_theme.dart';
 import 'package:wise_feedback/src/widgets/feedback_toast.dart';
 
 void main() {
@@ -11,6 +12,7 @@ void main() {
       MediaQuery(
         data: const MediaQueryData(),
         child: FeedbackToast(
+          theme: const WiseFeedbackTheme(),
           message: 'Saved',
           isError: false,
           onDismiss: () => dismissed++,

--- a/packages/wisecore/skills/flutter-widgets.md
+++ b/packages/wisecore/skills/flutter-widgets.md
@@ -46,6 +46,37 @@ lib/features/
         └── [item]_card.dart          # Card widget
 ```
 
+## One Widget Per File
+
+Every widget class gets its own file — **including the ones only a single screen
+uses**. A screen file should contain the screen and nothing else. Private
+`_Header` / `_LabeledField` classes appended below it, and `Widget _input(...)`
+builder methods inside its `State`, both belong in files of their own.
+
+Dart privacy is per *library*, so a widget cannot stay `_`-prefixed once it moves
+out — give it a real name and export it from the barrel. Don't reach for
+`part` / `part of` to preserve the underscore; no hand-written code in this repo
+does.
+
+```dart
+// DON'T — one file holding the screen, its sub-widgets and its builders
+// feedback_form.dart
+class FeedbackForm extends StatefulWidget { … }        // 200 lines
+class _Header extends StatelessWidget { … }            // + 60
+class _LabeledField extends StatelessWidget { … }      // + 40
+Widget _input(WiseFeedbackTheme theme, …) => TextField(…);   // + 30
+
+// DO — one widget per file, named, exported
+// feedback_form.dart          → FeedbackForm
+// feedback_form_header.dart   → FeedbackFormHeader
+// labeled_field.dart          → LabeledField
+// feedback_text_field.dart    → FeedbackTextField
+```
+
+A builder method that returns a widget is a widget wearing a disguise: it can't
+be `const`, doesn't get its own element, and can't be tested on its own. Promote
+it rather than growing it.
+
 ## Widget API Design
 
 How a widget exposes itself matters as much as what it renders.
@@ -471,3 +502,6 @@ export 'text_field.dart';
 15. **Scope MediaQuery reads** — Use the property accessor for what you read (`MediaQuery.sizeOf`, `.paddingOf`, `.viewInsetsOf`, `.viewPaddingOf`, `.textScalerOf`), not `MediaQuery.of(context)`, which rebuilds the widget on *every* metric change
 16. **Widgets take a `child`, not a builder function** — See "Widget API Design"; expose composition through a `child`, and own state locally rather than via `.of(context)` scope lookups
 17. **Use the named `SizedBox` constructors** — `SizedBox.square(dimension: 20)` when width and height match, `SizedBox.shrink()` for an empty slot, `SizedBox.expand()` to fill. They state the intent that `SizedBox(height: 20, width: 20)` only implies
+18. **One widget per file** — including single-use sub-widgets and `Widget _build…()` methods; see "One Widget Per File"
+19. **Go directional on any horizontal edge** — `EdgeInsetsDirectional.fromSTEB(16, 4, 16, 0)` over `EdgeInsets.fromLTRB`, `AlignmentDirectional` over `Alignment`, `BorderRadiusDirectional` over `BorderRadius`, and `start`/`end` over `left`/`right`. The non-directional forms hardcode left-to-right and silently mirror wrong in RTL locales. Purely vertical insets (`EdgeInsets.only(bottom: …)`, `symmetric(vertical: …)`) have no handedness — leave those alone
+20. **Don't hand-tune font metrics** — take text styles from the theme (`context.title`, `context.normal`, `context.label`). A `letterSpacing` or line-height lifted off a design file is calibrated to *that file's* typeface; applying it while leaving `fontFamily` unset pins a negative tracking value onto whatever font the platform happens to supply. If a design genuinely needs its own tracking, set the family it was designed for in the same `TextStyle`

--- a/packages/wisecore/skills/main-skill.md
+++ b/packages/wisecore/skills/main-skill.md
@@ -47,6 +47,7 @@ This is a Flutter application following a **feature-based clean architecture** w
 - Give void, side-effecting methods a block body (`{ … }`), not `=>`. An arrow returns its expression, so `void f() => _x = v;` silently returns the assigned value into `void` — a statement body reads as "does", not "returns"
 - Keep navigation out of state holders. A notifier or controller owns *state*; opening a sheet, pushing a route or showing a dialog is the widget's job — call it from `onPressed`. A `bindShow(callback)` / `setHandler(callback)` setter on a controller is the smell: it exists only so something else can trigger UI later, and it buys nothing over calling that code directly
 - Don't ship placeholder tests. A scaffolding test like `expect(1 + 1, 2)` proves nothing once real tests exist — delete it. It inflates the test count and hides the fact that a file, or a whole package, is untested
+- Don't narrate the code in comments. A comment that walks through what the widget tree contains, or restates the call it sits above, is deleted in review — the reader can see the code. Comment the things the code *can't* say: why a workaround exists, which upstream bug or API contract forces an odd shape, why a value that looks wrong is deliberate. Doc comments (`///`) on public API are the exception and stay
 
 ### Naming Conventions
 


### PR DESCRIPTION
Stacked on #74 . Restyles the feedback form to the Crispy design system.

### What's new
- A **header** with a circular close (X) and a brand submit (✓) action.
- **Labelled inputs** in soft-bordered 16px-radius boxes, styled dropdowns, and an indigo accent.
- A **drag handle** (grabber), and the whole form surface (grabber, header, fields) drags the sheet.
- All tokens (colors, radius, labels, sheet title) are themeable via `WiseFeedbackTheme` — nothing hardcoded, default-safe for other consumers.

Bumps to **0.4.0**.

### Testing
The latest changes can be tested in the **`test/wise-feedback-sandbox`** branch.