### PR TITLE
docs(wisecore): add skill conventions learned from PR #72 review

### DIFF
--- a/packages/wisecore/skills/flutter-screens.md
+++ b/packages/wisecore/skills/flutter-screens.md
@@ -366,3 +366,4 @@ export 'items_screen.dart';
 6. **Consistent spacing** — Use `SizeUtils.bottomSpacing()` for safe area padding
 7. **Barrel exports** — Always export from `screens.dart`
 8. **Use theme extensions** — Access colors via `context.bgColor`, `context.textColor`
+9. **Scope MediaQuery reads** — Prefer `MediaQuery.sizeOf(context)`, `.paddingOf`, `.viewInsetsOf`, `.viewPaddingOf` over `MediaQuery.of(context)`, which rebuilds the screen on *every* metric change (rotation, keyboard, text scale). Screens that read insets or size do this constantly

--- a/packages/wisecore/skills/flutter-widgets.md
+++ b/packages/wisecore/skills/flutter-widgets.md
@@ -46,6 +46,45 @@ lib/features/
         └── [item]_card.dart          # Card widget
 ```
 
+## Widget API Design
+
+How a widget exposes itself matters as much as what it renders.
+
+- **Widgets are classes, not functions.** Expose behavior as a widget that
+  takes a `child`, never as a function that wraps a widget
+  (e.g. `Widget wrap(BuildContext context, Controller c, Widget child)`).
+  Function-based widget APIs sit outside the element tree, can't be `const`,
+  and are awkward to compose and test. If a component augments a subtree,
+  it *is* a widget with a `child`.
+
+- **Own state locally; avoid global lookups.** Create state where it's used —
+  a field or `initState` in the owning widget's `State`. Reach for an
+  `InheritedWidget` / `.of(context)` lookup only when many descendants you
+  don't control must read the same state. A scope lookup is not a substitute
+  for passing a value down one or two levels.
+
+- **Expose only what varies.** Keep the public constructor small. Add a
+  parameter for a genuine per-use-site difference, not for everything that
+  *could* be configurable — an opinionated component with sensible defaults
+  is easier to use correctly than a wall of optional knobs.
+
+```dart
+// DON'T — function-based wrapper API
+abstract class FeedbackTrigger {
+  Widget wrap(BuildContext context, FeedbackController controller, Widget child);
+}
+
+// DO — a widget that takes a child and augments it
+class FeedbackOverlay extends StatefulWidget {
+  const FeedbackOverlay({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<FeedbackOverlay> createState() => _FeedbackOverlayState();
+}
+```
+
 ## Basic Widget Pattern
 
 Use `StatelessWidget` for simple widgets without state or Riverpod.
@@ -428,3 +467,6 @@ export 'text_field.dart';
 11. **Use InkWell for taps** — Always prefer `InkWell` over `GestureDetector` for clickable widgets
 12. **Ink over Container** — Use `Ink` (not `Container`) as the direct child of `InkWell` when decoration or color is needed
 13. **Material parent** — `InkWell` requires a `Material` ancestor; wrap with `Material(type: MaterialType.transparency)` unless `Material` itself provides the background color
+14. **Consume the theme; don't re-configure it** — Pull colors from `context.bgColor`, `context.fgColor`, etc. (see the theming skill). Don't add per-widget color/style parameters that duplicate the theme, and never hardcode hex colors like `Color(0xFFD32F2F)`
+15. **Scope MediaQuery reads** — Use the property accessor for what you read (`MediaQuery.sizeOf`, `.paddingOf`, `.viewInsetsOf`, `.viewPaddingOf`, `.textScalerOf`), not `MediaQuery.of(context)`, which rebuilds the widget on *every* metric change
+16. **Widgets take a `child`, not a builder function** — See "Widget API Design"; expose composition through a `child`, and own state locally rather than via `.of(context)` scope lookups

--- a/packages/wisecore/skills/main-skill.md
+++ b/packages/wisecore/skills/main-skill.md
@@ -41,6 +41,7 @@ This is a Flutter application following a **feature-based clean architecture** w
 - Use barrel exports (`feature.dart`) to expose public APIs
 - Follow the single responsibility principle
 - Keep files focused and small
+- Catch errors with `catch (e)` or `catch (e, stackTrace)` — never `on Object catch (e)` (identical, just noisier). Use `on SpecificType` only when handling that type specifically, and capture the stack trace when logging or forwarding the error
 
 ### Naming Conventions
 
@@ -168,3 +169,10 @@ flutter analyze
 - `drift_dev` — Drift code generation
 - `auto_route_generator` — Route code generation
 - `build_runner` — Code generation runner
+
+### Adding Dependencies
+
+Prefer pure-Dart / lightweight packages. Weigh native plugins carefully — they
+add build time, platform-support gaps (some are unsupported on older or
+non-standard devices), and permission requirements. Don't pull in a native
+dependency for a nice-to-have.

--- a/packages/wisecore/skills/network.md
+++ b/packages/wisecore/skills/network.md
@@ -351,3 +351,4 @@ dart run build_runner build --delete-conflicting-outputs
 4. **Separate read/write DTOs** — if request shape differs from response
 5. **Test mappers** — ensure all fields are correctly transformed
 6. **Use snake_case in JSON** — `fieldRename: FieldRename.snake`
+7. **Never embed third-party secrets in the app** — the app binary is decompilable, so any API key shipped in it can be extracted. Route third-party integrations through your own backend so their credentials stay server-side; the client should only ever carry the user's own session token (via the protected client)

--- a/packages/wisecore/skills/network.md
+++ b/packages/wisecore/skills/network.md
@@ -351,4 +351,3 @@ dart run build_runner build --delete-conflicting-outputs
 4. **Separate read/write DTOs** — if request shape differs from response
 5. **Test mappers** — ensure all fields are correctly transformed
 6. **Use snake_case in JSON** — `fieldRename: FieldRename.snake`
-7. **Never embed third-party secrets in the app** — the app binary is decompilable, so any API key shipped in it can be extracted. Route third-party integrations through your own backend so their credentials stay server-side; the client should only ever carry the user's own session token (via the protected client)


### PR DESCRIPTION
Codify the generalizable lessons from the wise_feedback review so they apply across every project:

- flutter-widgets: new "Widget API Design" section (widgets are classes that take a child, not function-based wrap() APIs; own state locally instead of .of(context) scope lookups; expose only what varies) plus best-practice bullets for consuming the theme (no per-widget color params / hardcoded hex) and scoping MediaQuery reads.
- flutter-screens: prefer property-scoped MediaQuery accessors over MediaQuery.of(context).
- main-skill: catch with `catch (e)` / `catch (e, stackTrace)`, not `on Object catch`; dependency-discipline note on native plugins.
- network: never embed third-party secrets in the app binary; proxy third-party integrations through your own backend.