### PR TITLE
docs(wisecore): Dart-style conventions from FeedbackController review

### DIFF
--- a/packages/wisecore/skills/main-skill.md
+++ b/packages/wisecore/skills/main-skill.md
@@ -42,6 +42,9 @@ This is a Flutter application following a **feature-based clean architecture** w
 - Follow the single responsibility principle
 - Keep files focused and small
 - Catch errors with `catch (e)` or `catch (e, stackTrace)` — never `on Object catch (e)` (identical, just noisier). Use `on SpecificType` only when handling that type specifically, and capture the stack trace when logging or forwarding the error
+- Model payload-less states as `static const` singletons, not const constructors (`FeedbackStatus.idle`, not `FeedbackStatus.idle()`). Keep constructors only for variants that carry data
+- Use Flutter's callback typedefs — `VoidCallback` for `void Function()`, `ValueChanged<T>` for `void Function(T)` — instead of writing the raw function type
+- Give void, side-effecting methods a block body (`{ … }`), not `=>`. An arrow returns its expression, so `void f() => _x = v;` silently returns the assigned value into `void` — a statement body reads as "does", not "returns"
 
 ### Naming Conventions
 


### PR DESCRIPTION
Adds three Dart-style conventions to the wisecore `main-skill.md` Code Style, learned from the lead-dev review of `FeedbackController` in the `wise_feedback` PR:

- Payload-less states as `static const` singletons, not const constructors.
- Flutter callback typedefs (`VoidCallback`, `ValueChanged<T>`) over raw `void Function()`.
- Block bodies for void side-effecting methods (an `=>` arrow silently returns its expression into `void`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)