### PR TITLE
Swift classifier bugfixes

### DIFF
--- a/packages/wise_text/CHANGELOG.md
+++ b/packages/wise_text/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2
+
+* Fixed crash where Swift classier would release() twice
+* Changed disposing ownership for `WiseTextClassifier` with custom classifiers
+* `WiseTextWidget` doesn't initialize a classifier anymore when the widget's classified is false
+
 ## 1.0.1
 
 * Bugfixes to FFI calls

--- a/packages/wise_text/lib/src/classifier/wise_text_classifier.dart
+++ b/packages/wise_text/lib/src/classifier/wise_text_classifier.dart
@@ -10,7 +10,8 @@ import 'classifier.dart';
 class WiseTextClassifier {
   /// Creates [WiseTextClassifier] instance with [WiseTextClassifierInterface] platform implementation or given classifier
   WiseTextClassifier({WiseTextClassifierInterface? classifier})
-    : instance = switch (classifier) {
+    : _externalClassifier = classifier != null,
+      instance = switch (classifier) {
         WiseTextClassifierInterface() => classifier,
         null when Platform.isIOS || Platform.isMacOS => WiseTextClassifierIos(),
         null when Platform.isAndroid => WiseTextClassifierAndroid(),
@@ -28,7 +29,16 @@ class WiseTextClassifier {
   Future<List<ItemSpan>> classify(String text) => instance.classifyText(text);
 
   /// Disposes of native references used by FFI classes
-  void dispose() => instance.dispose();
+  void dispose() {
+    if (!_externalClassifier) {
+      instance.dispose();
+    }
+  }
+
+  /// Check ownership of the classifier before disposing
+  /// If 2 Widgets use the same classifier then UseAfterReleaseError will be thrown
+  /// after a disposed classifier is used
+  final bool _externalClassifier;
 }
 
 /// Classifies text into typed [ItemSpan]s (dates, addresses, links and phone

--- a/packages/wise_text/lib/src/classifier/wise_text_classifier_ios.dart
+++ b/packages/wise_text/lib/src/classifier/wise_text_classifier_ios.dart
@@ -25,6 +25,9 @@ class WiseTextClassifierIos implements WiseTextClassifierInterface {
 
   @override
   void dispose() {
-    _native.release();
+    // Throws DoubleReleaseError (native crash) on a second call, that's why this is guarded
+    if (!_native.ref.isReleased) {
+      _native.ref.release();
+    }
   }
 }

--- a/packages/wise_text/lib/src/widget/wise_text_widget.dart
+++ b/packages/wise_text/lib/src/widget/wise_text_widget.dart
@@ -126,25 +126,24 @@ class WiseTextWidget extends StatefulWidget {
 }
 
 class _WiseTextWidgetState extends State<WiseTextWidget> {
-  late WiseTextClassifier classifier;
+  WiseTextClassifier? classifier;
   late Future<String> classifiedText;
 
   @override
   void initState() {
     super.initState();
-    classifier = WiseTextClassifier(classifier: widget.classifier);
+    if (widget.classified) {
+      classifier = WiseTextClassifier(classifier: widget.classifier);
+    }
     classifiedText = processText();
   }
 
   Future<String> processText() async {
-    if (widget.classified) {
-      try {
-        final classifiedItems = await classifier.classify(widget.text);
-        return classifiedItems.map((e) => e.tag).join();
-      } catch (e) {
-        return widget.text;
-      }
-    } else {
+    if (!widget.classified || classifier == null) return widget.text;
+    try {
+      final classifiedItems = await classifier!.classify(widget.text);
+      return classifiedItems.map((e) => e.tag).join();
+    } catch (e) {
       return widget.text;
     }
   }
@@ -155,8 +154,12 @@ class _WiseTextWidgetState extends State<WiseTextWidget> {
     if (oldWidget.text != widget.text ||
         oldWidget.classified != widget.classified ||
         changedClassifier) {
-      if (changedClassifier) {
-        classifier = WiseTextClassifier(classifier: widget.classifier);
+      if (changedClassifier || !widget.classified) {
+        classifier?.dispose();
+        classifier = null;
+      }
+      if (widget.classified) {
+        classifier ??= WiseTextClassifier(classifier: widget.classifier);
       }
       classifiedText = processText();
     }
@@ -165,7 +168,7 @@ class _WiseTextWidgetState extends State<WiseTextWidget> {
 
   @override
   void dispose() {
-    classifier.dispose();
+    classifier?.dispose();
     super.dispose();
   }
 

--- a/packages/wise_text/pubspec.yaml
+++ b/packages/wise_text/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wise_text
 description: "Text widget with auto classification and rich text support using styled_text. Using NSDataDetector on iOS and TextClassifier on Android"
-version: 1.0.1
+version: 1.0.2
 homepage: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_text
 repository: https://github.com/wisemen-digital/wisemen-flutter-packages/packages/wise_text
 


### PR DESCRIPTION
* Fixed crash where Swift classier would release() twice
* Changed disposing ownership for `WiseTextClassifier` with custom classifiers
* `WiseTextWidget` doesn't initialize a classifier anymore when the widget's classified is false